### PR TITLE
Fix bug in asyncWithLDProvider

### DIFF
--- a/src/asyncWithLDProvider.tsx
+++ b/src/asyncWithLDProvider.tsx
@@ -52,7 +52,9 @@ export default async function asyncWithLDProvider(config: ProviderConfig) {
           const flagKey = reactOptions.useCamelCaseFlagKeys ? camelCase(key) : key;
           flattened[flagKey] = changes[key].current;
         }
-        setLDData({ flags: { ...ldData.flags, ...flattened }, ldClient });
+        setLDData(({flags, ldClient}) => {
+          return { flags: { ...flags, ...flattened }, ldClient }
+        });
       });
     }, []);
 


### PR DESCRIPTION
Fixes bug where changes were applied to the original flags objects from initialization. The object `ldData.flags` would retain a reference to the original flag set instead of being updated with the new merged object set in the change event.

In order to remediate this, we can grab the current state of the flags by passing a function to `setLDData` instead of an object.

For example, given this initial state:
```
flag1: on
flag2: off
flag3: off
```

After a changing flag2 to on:
```
flag1: on
flag2: on
flag3: off
```

After changing flag3 to on:
```
flag1: on
flag2: off <-- incorrectly set to original status!
flag3: on
```

**Requirements**

- [ ] I have added test coverage for new or changed functionality
- [ ] I have followed the repository's [pull request submission guidelines](../blob/master/CONTRIBUTING.md#submitting-pull-requests)
- [ ] I have validated my changes against all supported platform versions

**Related issues**

Provide links to any issues in this repository or elsewhere relating to this pull request.

**Describe the solution you've provided**

Provide a clear and concise description of what you expect to happen.

**Describe alternatives you've considered**

Provide a clear and concise description of any alternative solutions or features you've considered.

**Additional context**

Add any other context about the pull request here.
