### PR TITLE
prepare 2.17.1 release

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "typescript": "^3.6.2"
   },
   "dependencies": {
-    "launchdarkly-js-client-sdk": "2.16.0",
+    "launchdarkly-js-client-sdk": "2.16.3",
     "lodash.camelcase": "^4.3.0",
     "uuid": "^3.3.2"
   },

--- a/src/withLDProvider.tsx
+++ b/src/withLDProvider.tsx
@@ -27,7 +27,7 @@ import { camelCaseKeys } from './utils';
  * @return A function which accepts your root React component and returns a HOC
  */
 export function withLDProvider(config: ProviderConfig) {
-  return function withLDPoviderHoc<P>(WrappedComponent: React.ComponentType<P>) {
+  return function withLDProviderHoc<P>(WrappedComponent: React.ComponentType<P>) {
     const { options, reactOptions: userReactOptions } = config;
     const reactOptions = { ...defaultReactOptions, ...userReactOptions };
 


### PR DESCRIPTION
## [2.17.1] - 2020-02-10
### Fixed:
- Updated JS SDK dependency version from 2.16.0 to 2.16.3 for several recent fixes. See release notes for [2.16.1](https://github.com/launchdarkly/js-client-sdk/releases/tag/2.16.1), [2.16.2](https://github.com/launchdarkly/js-client-sdk/releases/tag/2.16.2), [2.16.3](https://github.com/launchdarkly/js-client-sdk/releases/tag/2.16.3).

Note that while some transitive dependencies have been changed from exact versions to &#34;best compatible&#34; versions, the dependency on `js-client-sdk` is still an exact version dependency so that each release of `react-client-sdk` has well-defined behavior.
