### PR TITLE
upgrade launchdarkly-js-client-sdk version to ^2.17.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4654,18 +4654,18 @@
       "dev": true
     },
     "launchdarkly-js-client-sdk": {
-      "version": "2.17.0",
-      "resolved": "https://registry.npmjs.org/launchdarkly-js-client-sdk/-/launchdarkly-js-client-sdk-2.17.0.tgz",
-      "integrity": "sha512-KLKFtud5k9tH2BsaCf7dNyfqaHM4MITLQbriDpqi5zYDAhNYh6qZRIuriCTOohhw0/0GoA+oMHDhI4zDQ7nVww==",
+      "version": "2.17.5",
+      "resolved": "https://registry.npmjs.org/launchdarkly-js-client-sdk/-/launchdarkly-js-client-sdk-2.17.5.tgz",
+      "integrity": "sha512-ca6Dud0uD63GOh3ghIFzWi9IkRtAKsI29GWJNvL6TSrWH0Ez/IddAu6GqVK/6SSPOpNCOl+LjVxFIYtoDv4pLA==",
       "requires": {
         "escape-string-regexp": "^1.0.5",
-        "launchdarkly-js-sdk-common": "3.2.2"
+        "launchdarkly-js-sdk-common": "3.2.8"
       }
     },
     "launchdarkly-js-sdk-common": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/launchdarkly-js-sdk-common/-/launchdarkly-js-sdk-common-3.2.2.tgz",
-      "integrity": "sha512-WBIMk3c1s3JGpSvDRZpDr0D4dDPsFkscDmcOoaoXnkW6PdacfUz9KKJ9bKTM+akNWE2DsZ3ttEz4rATEFeOnVA==",
+      "version": "3.2.8",
+      "resolved": "https://registry.npmjs.org/launchdarkly-js-sdk-common/-/launchdarkly-js-sdk-common-3.2.8.tgz",
+      "integrity": "sha512-inZVhqRPJcs9jIOeEHFb5LmNbemWMRx2jJY0VIQajKAaDymseGxx2XVfeZukTrNKyB5JBNVMYpTRvnawWuLJQw==",
       "requires": {
         "base64-js": "^1.3.0",
         "fast-deep-equal": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "typescript": "^3.6.2"
   },
   "dependencies": {
-    "launchdarkly-js-client-sdk": "2.17.0",
+    "launchdarkly-js-client-sdk": "^2.17.5",
     "lodash.camelcase": "^4.3.0",
     "uuid": "^3.3.2"
   },


### PR DESCRIPTION
The react SDK is using a fixed version of `launchdarkly-js-client-sdk`, which is missing some important bug fixes. This upgrades the dependency and applies a caret range so future bugfixes in the JS SDK can be consumed.

I'm happy to change it back to a non-caret range if that's preferred.

- [x] I have added test coverage for new or changed functionality
- [x] I have followed the repository's [pull request submission guidelines](../blob/master/CONTRIBUTING.md#submitting-pull-requests)
- [x] I have validated my changes against all supported platform versions
