### PR TITLE
allow ldClient to be initialized manually

### DIFF
--- a/src/__snapshots__/withLDProvider.test.tsx.snap
+++ b/src/__snapshots__/withLDProvider.test.tsx.snap
@@ -5,6 +5,7 @@ exports[`withLDProvider render app 1`] = `
   value={
     Object {
       "flags": Object {},
+      "initLDClient": [Function],
       "ldClient": undefined,
     }
   }

--- a/src/asyncWithLDProvider.test.tsx
+++ b/src/asyncWithLDProvider.test.tsx
@@ -58,7 +58,7 @@ describe('asyncWithLDProvider', () => {
 
   test('ldClient is initialised correctly', async () => {
     const options: LDOptions = { bootstrap: {} };
-    const reactOptions: LDReactOptions = { useCamelCaseFlagKeys: false };
+    const reactOptions: LDReactOptions = { manualyInitializeLDClient: false, useCamelCaseFlagKeys: false };
     await asyncWithLDProvider({ clientSideID, user, options, reactOptions });
 
     expect(mockInitLDClient).toHaveBeenCalledWith(clientSideID, user, reactOptions, options, undefined);

--- a/src/asyncWithLDProvider.tsx
+++ b/src/asyncWithLDProvider.tsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect, FunctionComponent } from 'react';
 import camelCase from 'lodash.camelcase';
 import { LDFlagSet, LDFlagChangeset } from 'launchdarkly-js-client-sdk';
 import { defaultReactOptions, ProviderConfig } from './types';
-import { Provider } from './context';
+import { LDContext, Provider } from './context';
 import initLDClient from './initLDClient';
 import { camelCaseKeys } from './utils';
 
@@ -31,8 +31,9 @@ export default async function asyncWithLDProvider(config: ProviderConfig) {
   const { flags: fetchedFlags, ldClient } = await initLDClient(clientSideID, user, reactOptions, options, flags);
 
   const LDProvider: FunctionComponent = ({ children }) => {
-    const [ldData, setLDData] = useState({
+    const [ldData, setLDData] = useState<LDContext>({
       flags: fetchedFlags,
+      initLDClient: () => undefined,
       ldClient,
     });
 

--- a/src/context.ts
+++ b/src/context.ts
@@ -1,5 +1,5 @@
 import { createContext } from 'react';
-import { LDClient, LDFlagSet } from 'launchdarkly-js-client-sdk';
+import { LDClient, LDFlagSet, LDUser } from 'launchdarkly-js-client-sdk';
 
 /**
  * The LaunchDarkly context stored in the Provider state and passed to consumers.
@@ -10,6 +10,18 @@ interface LDContext {
    * until flags are fetched from the LaunchDarkly servers.
    */
   flags: LDFlagSet;
+
+  /**
+   * A function to initialize the ldClient.
+   *
+   * Normally, the ldClient is automatically initialized for you, but if you set reactOptions.manualyInitializeLDClient
+   * to true, then you will have to manually call initLDClient.
+   *
+   * initLDClient will not execute if the ldClient has already been initialized.
+   *
+   * initLDClient will not execute if you are using asyncWithLDProvider since the ldClient is initialized for you.
+   */
+  initLDClient(user?: LDUser): void;
 
   /**
    * An instance of `LDClient` from the LaunchDarkly JS SDK (`launchdarkly-js-client-sdk`).
@@ -23,7 +35,7 @@ interface LDContext {
 /**
  * @ignore
  */
-const context = createContext<LDContext>({ flags: {}, ldClient: undefined });
+const context = createContext<LDContext>({ flags: {}, initLDClient: () => undefined, ldClient: undefined });
 const {
   /**
    * @ignore

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,6 +7,18 @@ import * as React from 'react';
  */
 export interface LDReactOptions {
   /**
+   * If set to true, the LDClient will not be initialzed until initLDClient() is called.
+   *
+   * An example of when this flag would be used is if your user object is fetched asynchronously and
+   * you want to wait for your user object before initializing the client.
+   *
+   * This is false by default, meaning the ldClient will be initialized for you, even if a config.user is undefined.
+   *
+   * This flag will not have any effect if you are using asyncWithLDProvider.
+   */
+  manualyInitializeLDClient?: boolean;
+
+  /**
    * Whether the React SDK should transform flag keys into camel-cased format.
    * Using camel-cased flag keys allow for easier use as prop values, however,
    * these keys won't directly match the flag keys as known to LaunchDarkly.
@@ -26,7 +38,7 @@ export interface LDReactOptions {
 /**
  * Contains default values for the `reactOptions` object.
  */
-export const defaultReactOptions = { useCamelCaseFlagKeys: true };
+export const defaultReactOptions = { manualyInitializeLDClient: false, useCamelCaseFlagKeys: true };
 
 /**
  * Configuration object used to initialise LaunchDarkly's JS client.
@@ -76,7 +88,7 @@ export interface ProviderConfig {
 export interface EnhancedComponent extends React.Component {
   subscribeToChanges(ldClient: LDClient): void;
   // tslint:disable-next-line:invalid-void
-  componentDidMount(): Promise<void>;
+  componentDidMount(): void;
 }
 
 /**


### PR DESCRIPTION
**Related issues**
- https://github.com/launchdarkly/react-client-sdk/issues/28
- https://github.com/launchdarkly/js-client-sdk/issues/174

There are a couple of open issues that relate to this PR. The main issue I am addressing is the fact that the LD React SDK will initialize the ldClient on `componentDidMount`. The problem we are facing is that our user object is fetched asynchronously, so SDK always assumes that our user is anonymous and fetches flags for an anonymous user. This can cause a flash since the flags fetched for the anonymous user can be different from the authenticated user. Additionally, we incur an extra MAU for the anonymous user. I believe this is also affecting our partial rollouts since the number of users is not accurate. This has prevented us from using the insights feature.

**Describe the solution you've provided**
My solution was to create a function called `initLDClient` that gets passed through context. This will allow the user to manually call `initLDClient` once the user object has been fetched. I also added `reactOptions.manualyInitializeLDClient` which will prevent the SDK from automatically initializing.

Provide a clear and concise description of what you expect to happen.

**Describe alternatives you've considered**
Another approach will be to export LDProvider as a standalone component and make the initialization of ldClient be reactive to the existence of a user object. In other words, the ldClient will only initialize once a user object has been provided.

Since we are using Next.js we were not able to use withLDProvider to wrap our app. We had to use a workaround where the LDProvider only wraps a subset of our app. our solution looks something like this:

```
export const withLDProvider = withLDProviderOriginal({
  clientSideID: getConfig('launchDarkly.clientSideId'),
});
const LDProviderInner = ({ children }: { children: any }) => {
  return children;
};
export const LDProvider = withLDProvider(LDProviderInner);
```

https://github.com/launchdarkly/react-client-sdk/pull/28 looks like it creates a standalone `LDProvider`, but it still initializes the ldClient on `componentDidMount`. If it's preferred, I may be able to fork that PR and that that functionality.

I have not written any tests for this PR. I am happy to do so if LD is happy with this implementation.

This is an important problem for us to fix so we are happy to help to get this over the finish line. Thanks!