### PR TITLE
Fixing camelCaseKeys export

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,6 @@ import asyncWithLDProvider from './asyncWithLDProvider';
 import withLDConsumer from './withLDConsumer';
 import useFlags from './useFlags';
 import useLDClient from './useLDClient';
-import camelCaseKeys from './utils';
+import { camelCaseKeys } from './utils';
 
 export { LDProvider, withLDProvider, withLDConsumer, useFlags, useLDClient, asyncWithLDProvider, camelCaseKeys };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -48,4 +48,7 @@ export const getFlattenedFlagsFromChangeset = (
   return flattened;
 };
 
+// TODO: Remove this for the next major version. This was added to maintain backwards compatibility.
+camelCaseKeys.camelCaseKeys = camelCaseKeys;
+
 export default { camelCaseKeys, getFlattenedFlagsFromChangeset };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -48,7 +48,11 @@ export const getFlattenedFlagsFromChangeset = (
   return flattened;
 };
 
-// TODO: Remove this for the next major version. This was added to maintain backwards compatibility.
+/**
+ * @deprecated The `camelCaseKeys.camelCaseKeys` property will be removed in a future version,
+ * please update your code to use the `camelCaseKeys` function directly.
+ */
+// tslint:disable-next-line deprecation
 camelCaseKeys.camelCaseKeys = camelCaseKeys;
 
 export default { camelCaseKeys, getFlattenedFlagsFromChangeset };


### PR DESCRIPTION
Currently, the `camelCaseKeys` is an object with a `camelCaseKeys` property. Which means it has to be accessed as `camelCaseKeys.camelCaseKeys`:

```js
import { camelCaseKeys } from 'launchdarkly-react-client-sdk';

const flags = camelCaseKeys.camelCaseKeys(ldClient.allFlags());
```

Or the import can be renamed:

```js
import { camelCaseKeys as LDUtils } from 'launchdarkly-react-client-sdk';

const flags = LDUtils.camelCaseKeys(ldClient.allFlags());
```

This change fixes the export so that the `camelCaseKeys` function is directly exported, which seems to be what was intended by the existing code.

As it is, this is a breaking change, but I can update it to be backwards compatible if needed.

**Requirements**

- [ ] I have added test coverage for new or changed functionality **This PR does not include new functionality**
- [x] I have followed the repository's [pull request submission guidelines](../blob/master/CONTRIBUTING.md#submitting-pull-requests)
- [x] I have validated my changes against all supported platform versions

**Related issues**

Provide links to any issues in this repository or elsewhere relating to this pull request.

**Describe the solution you've provided**

Provide a clear and concise description of what you expect to happen.

**Describe alternatives you've considered**

Provide a clear and concise description of any alternative solutions or features you've considered.

**Additional context**

Add any other context about the pull request here.
