### PR TITLE
Mock provider

### DIFF
--- a/src/__snapshots__/mockProvider.test.tsx.snap
+++ b/src/__snapshots__/mockProvider.test.tsx.snap
@@ -1,0 +1,8 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`MockProvider allows the usage of \`useFlags\` with the given mocked flags 1`] = `
+<div>
+  Value: 
+  my-test
+</div>
+`;

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,5 +5,15 @@ import withLDConsumer from './withLDConsumer';
 import useFlags from './useFlags';
 import useLDClient from './useLDClient';
 import camelCaseKeys from './utils';
+import context from './context';
 
-export { LDProvider, withLDProvider, withLDConsumer, useFlags, useLDClient, asyncWithLDProvider, camelCaseKeys };
+export {
+  asyncWithLDProvider,
+  camelCaseKeys,
+  context,
+  LDProvider,
+  useFlags,
+  useLDClient,
+  withLDConsumer,
+  withLDProvider,
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 import LDProvider from './provider';
+import MockProvider from './mockProvider';
 import withLDProvider from './withLDProvider';
 import asyncWithLDProvider from './asyncWithLDProvider';
 import withLDConsumer from './withLDConsumer';
@@ -12,6 +13,7 @@ export {
   camelCaseKeys,
   context,
   LDProvider,
+  MockProvider,
   useFlags,
   useLDClient,
   withLDConsumer,

--- a/src/mockProvider.test.tsx
+++ b/src/mockProvider.test.tsx
@@ -1,0 +1,22 @@
+import React, { FunctionComponent } from 'react';
+import { create } from 'react-test-renderer';
+import MockProvider from './mockProvider';
+import { useFlags } from './index';
+
+const MockApp: FunctionComponent = () => {
+  const flags = useFlags();
+
+  return <div>Value: {`${flags.testFlag}`}</div>;
+};
+
+describe('MockProvider', () => {
+  it('allows the usage of `useFlags` with the given mocked flags', () => {
+    const LaunchDarklyApp = (
+      <MockProvider flags={{ testFlag: 'my-test' }}>
+        <MockApp />
+      </MockProvider>
+    );
+    const component = create(LaunchDarklyApp);
+    expect(component).toMatchSnapshot();
+  });
+});

--- a/src/mockProvider.tsx
+++ b/src/mockProvider.tsx
@@ -1,0 +1,9 @@
+import React, { FunctionComponent } from 'react';
+import { LDFlagSet } from 'launchdarkly-js-client-sdk';
+import { Provider } from './context';
+
+const MockProvider: FunctionComponent<{ flags: LDFlagSet }> = ({ flags, children }) => (
+  <Provider value={{ flags }}>{children}</Provider>
+);
+
+export default MockProvider;


### PR DESCRIPTION
**Requirements**

- [x] I have added test coverage for new or changed functionality
- [x] I have followed the repository's [pull request submission guidelines](../blob/master/CONTRIBUTING.md#submitting-pull-requests)
- [x] I have validated my changes against all supported platform versions

**Related issues**

#30 

**Describe the solution you've provided**

On one hand, the `context` is exported now directly on the index so we can use it without having to import from nested imports, which causes issues in some setups.

On the other, I've added a `MockProvider` that can be used for testing, mock-only mode, etc. The `useFlags()` hook and consumers will work as usual and they will always receive the `flags` object passed to `MockProvider`.

**Describe alternatives you've considered**

they are discussed in #30

