### PR TITLE
HOC static hoisting

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1097,6 +1097,16 @@
         "@types/node": "*"
       }
     },
+    "@types/hoist-non-react-statics": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz",
+      "integrity": "sha512-iMIqiko6ooLrTh1joXodJK5X9xeEALT1kM5G3ZLhD3hszxBdIEd5C75U834D9mLcINgD4OyZf5uQXjkuYydWvA==",
+      "dev": true,
+      "requires": {
+        "@types/react": "*",
+        "hoist-non-react-statics": "^3.3.0"
+      }
+    },
     "@types/istanbul-lib-coverage": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.3.tgz",
@@ -3110,6 +3120,14 @@
             "is-buffer": "^1.1.5"
           }
         }
+      }
+    },
+    "hoist-non-react-statics": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+      "requires": {
+        "react-is": "^16.7.0"
       }
     },
     "hosted-git-info": {
@@ -5898,8 +5916,7 @@
     "react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "dev": true
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
     "react-shallow-renderer": {
       "version": "16.14.1",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "@testing-library/jest-dom": "^4.1.0",
     "@testing-library/react": "^11.2.6",
     "@types/enzyme": "^3.10.3",
+    "@types/hoist-non-react-statics": "^3.3.1",
     "@types/jest": "^25.2.3",
     "@types/lodash.camelcase": "^4.3.6",
     "@types/prop-types": "^15.7.2",
@@ -58,6 +59,7 @@
     "typescript": "~3.8.3"
   },
   "dependencies": {
+    "hoist-non-react-statics": "^3.3.2",
     "launchdarkly-js-client-sdk": "2.19.2",
     "lodash.camelcase": "^4.3.0",
     "uuid": "^3.3.2"

--- a/src/withLDProvider.tsx
+++ b/src/withLDProvider.tsx
@@ -23,13 +23,13 @@ import hoistNonReactStatics from 'hoist-non-react-statics';
  * @param config - The configuration used to initialize LaunchDarkly's JS SDK
  * @return A function which accepts your root React component and returns a HOC
  */
-export function withLDProvider(config: ProviderConfig): any {
-  return function withLDProviderHoc<P>(WrappedComponent: React.ComponentType<P>) {
+export function withLDProvider(config: ProviderConfig): (WrappedComponent: React.ComponentType) => React.ComponentType {
+  return function withLDProviderHoc(WrappedComponent: React.ComponentType): React.ComponentType {
     const { reactOptions: userReactOptions } = config;
     const reactOptions = { ...defaultReactOptions, ...userReactOptions };
     const providerProps = { ...config, reactOptions };
 
-    class HoistedComponent extends React.Component<P> {
+    class HoistedComponent extends React.Component {
       render() {
         return (
           <LDProvider {...providerProps}>
@@ -40,6 +40,7 @@ export function withLDProvider(config: ProviderConfig): any {
     }
 
     hoistNonReactStatics(HoistedComponent, WrappedComponent);
+
     return HoistedComponent;
   };
 }

--- a/src/withLDProvider.tsx
+++ b/src/withLDProvider.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { defaultReactOptions, ProviderConfig } from './types';
 import LDProvider from './provider';
+import hoistNonReactStatics from 'hoist-non-react-statics';
 
 /**
  * `withLDProvider` is a function which accepts a config object which is used to
@@ -22,13 +23,13 @@ import LDProvider from './provider';
  * @param config - The configuration used to initialize LaunchDarkly's JS SDK
  * @return A function which accepts your root React component and returns a HOC
  */
-export function withLDProvider(config: ProviderConfig) {
+export function withLDProvider(config: ProviderConfig): any {
   return function withLDProviderHoc<P>(WrappedComponent: React.ComponentType<P>) {
     const { reactOptions: userReactOptions } = config;
     const reactOptions = { ...defaultReactOptions, ...userReactOptions };
     const providerProps = { ...config, reactOptions };
 
-    return class extends React.Component<P> {
+    class HoistedComponent extends React.Component<P> {
       render() {
         return (
           <LDProvider {...providerProps}>
@@ -36,7 +37,10 @@ export function withLDProvider(config: ProviderConfig) {
           </LDProvider>
         );
       }
-    };
+    }
+
+    hoistNonReactStatics(HoistedComponent, WrappedComponent);
+    return HoistedComponent;
   };
 }
 


### PR DESCRIPTION
**Requirements**

- [x] I have added test coverage for new or changed functionality
- [x] I have followed the repository's [pull request submission guidelines](../blob/master/CONTRIBUTING.md#submitting-pull-requests)
- [x] I have validated my changes against all supported platform versions

**Related issues**

resolves #68 

**Describe the solution you've provided**

Based on the solution proposed here: https://github.com/launchdarkly/react-client-sdk/issues/68#issue-869219074
Allowing for the `withLDProvider` HOC to hoist statics

**Additional context**

This PR adds the dependency: `hoist-non-react-statics` and dev-dependency: `@types/hoist-non-react-statics`.
React docs ref: https://reactjs.org/docs/higher-order-components.html#static-methods-must-be-copied-over