### PR TITLE
fix: improve types of withLDProvider

### DIFF
--- a/src/withLDProvider.tsx
+++ b/src/withLDProvider.tsx
@@ -23,13 +23,17 @@ import hoistNonReactStatics from 'hoist-non-react-statics';
  * @param config - The configuration used to initialize LaunchDarkly's JS SDK
  * @return A function which accepts your root React component and returns a HOC
  */
-export function withLDProvider(config: ProviderConfig): (WrappedComponent: React.ComponentType) => React.ComponentType {
-  return function withLDProviderHoc(WrappedComponent: React.ComponentType): React.ComponentType {
+export function withLDProvider<T = {}>(
+  config: ProviderConfig
+): (WrappedComponent: React.ComponentType<T>) => React.ComponentType<T> {
+  return function withLDProviderHoc(
+    WrappedComponent: React.ComponentType<T>
+  ): React.ComponentType<T> {
     const { reactOptions: userReactOptions } = config;
     const reactOptions = { ...defaultReactOptions, ...userReactOptions };
     const providerProps = { ...config, reactOptions };
 
-    class HoistedComponent extends React.Component {
+    class HoistedComponent extends React.Component<T> {
       render() {
         return (
           <LDProvider {...providerProps}>


### PR DESCRIPTION
**Requirements**

- [x] I have added test coverage for new or changed functionality
- [x] I have followed the repository's [pull request submission guidelines](../blob/master/CONTRIBUTING.md#submitting-pull-requests)
- [x] I have validated my changes against all supported platform versions

**Related issues**

N/A

**Describe the solution you've provided**

Currently, the way that the `withLDProvider` function is implemented, end-users are unable to supply prop types for the wrapped component. This results in the type of the wrapped component to always be `React.ComponentType<{}>` which causes errors when the component is actually expected to have props.

This change makes the `withLDProvider` a generic function that end-users can supply props to.

**Describe alternatives you've considered**

There are no alternatives that I'm aware of.

**Additional context**

Ran into this issue in our codebase this afternoon. Pushing out a fix for this would be greatly appreciated.