### PR TITLE
Replace arrow functions with normal functions

### DIFF
--- a/src/asyncWithLDProvider.tsx
+++ b/src/asyncWithLDProvider.tsx
@@ -34,7 +34,7 @@ export default async function asyncWithLDProvider(config: AsyncProviderConfig) {
   const reactOptions = { ...defaultReactOptions, ...userReactOptions };
   const { ldClient } = await initLDClient(clientSideID, user, reactOptions, options, targetFlags);
 
-  const LDProvider = ({ children }: { children: ReactNode }) => {
+  function LDProvider({ children }: { children: ReactNode }) {
     const [ldData, setLDData] = useState({
       flags: fetchFlags(ldClient, reactOptions, targetFlags),
       ldClient,
@@ -58,7 +58,7 @@ export default async function asyncWithLDProvider(config: AsyncProviderConfig) {
     }, []);
 
     return <Provider value={ldData}>{children}</Provider>;
-  };
+  }
 
   return LDProvider;
 }

--- a/src/useFlags.ts
+++ b/src/useFlags.ts
@@ -10,10 +10,8 @@ import context, { LDContext } from './context';
  *
  * @return All the feature flags configured in your LaunchDarkly project
  */
-const useFlags = <T extends LDFlagSet = LDFlagSet>(): T => {
+export default function useFlags<T extends LDFlagSet = LDFlagSet>(): T {
   const { flags } = useContext<LDContext>(context);
 
   return flags as T;
-};
-
-export default useFlags;
+}

--- a/src/useLDClient.ts
+++ b/src/useLDClient.ts
@@ -11,10 +11,8 @@ import context from './context';
  * @return The `launchdarkly-js-client-sdk` `LDClient` object
  */
 // tslint:enable:max-line-length
-const useLDClient = () => {
+export default function useLDClient() {
   const { ldClient } = useContext(context);
 
   return ldClient;
-};
-
-export default useLDClient;
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -9,7 +9,7 @@ import { defaultReactOptions, LDReactOptions } from './types';
  * @param rawFlags A mapping of flag keys and their values
  * @return A transformed `LDFlagSet` with camelCased flag keys
  */
-export const camelCaseKeys = (rawFlags: LDFlagSet) => {
+export function camelCaseKeys(rawFlags: LDFlagSet) {
   const flags: LDFlagSet = {};
   for (const rawFlag in rawFlags) {
     // Exclude system keys
@@ -19,7 +19,7 @@ export const camelCaseKeys = (rawFlags: LDFlagSet) => {
   }
 
   return flags;
-};
+}
 
 /**
  * Gets the flags to pass to the provider from the changeset.
@@ -31,11 +31,11 @@ export const camelCaseKeys = (rawFlags: LDFlagSet) => {
  * @return an `LDFlagSet` with the current flag values from the LDFlagChangeset filtered by `targetFlags`. The returned
  * object may be empty `{}` if none of the targetFlags were changed.
  */
-export const getFlattenedFlagsFromChangeset = (
+export function getFlattenedFlagsFromChangeset(
   changes: LDFlagChangeset,
   targetFlags: LDFlagSet | undefined,
   reactOptions: LDReactOptions,
-): LDFlagSet => {
+): LDFlagSet {
   const flattened: LDFlagSet = {};
   for (const key in changes) {
     if (!targetFlags || targetFlags[key] !== undefined) {
@@ -46,7 +46,7 @@ export const getFlattenedFlagsFromChangeset = (
   }
 
   return flattened;
-};
+}
 
 /**
  * Retrieves flag values.
@@ -57,11 +57,11 @@ export const getFlattenedFlagsFromChangeset = (
  *
  * @returns an `LDFlagSet` with the current flag values from LaunchDarkly filtered by `targetFlags`.
  */
-export const fetchFlags = (
+export function fetchFlags(
   ldClient: LDClient,
   reactOptions: LDReactOptions = defaultReactOptions,
   targetFlags?: LDFlagSet,
-) => {
+) {
   let rawFlags: LDFlagSet = {};
 
   if (targetFlags) {
@@ -73,7 +73,7 @@ export const fetchFlags = (
   }
 
   return reactOptions.useCamelCaseFlagKeys ? camelCaseKeys(rawFlags) : rawFlags;
-};
+}
 
 /**
  * @deprecated The `camelCaseKeys.camelCaseKeys` property will be removed in a future version,


### PR DESCRIPTION
**Requirements**

- [x] I have added test coverage for new or changed functionality
- [x] I have followed the repository's [pull request submission guidelines](../blob/master/CONTRIBUTING.md#submitting-pull-requests)
- [x] I have validated my changes against all supported platform versions

**Describe the solution you've provided**

Shaves off a few bytes from the bundle by using normal functions instead of arrow functions which, the way they were defined, need to have `const` behavior unnecessarily simulated.
