### PR TITLE
Fix TypeScript warning

### DIFF
--- a/src/initLDClient.ts
+++ b/src/initLDClient.ts
@@ -1,7 +1,7 @@
 import { initialize as ldClientInitialize, LDFlagSet, LDOptions, LDUser } from 'launchdarkly-js-client-sdk';
 import { AllFlagsLDClient, defaultReactOptions, LDReactOptions } from './types';
 import { fetchFlags } from './utils';
-import { version } from '../package.json';
+import * as packageInfo from '../package.json';
 
 /**
  * Internal function to initialize the `LDClient`.
@@ -22,7 +22,7 @@ const initLDClient = async (
   options?: LDOptions,
   targetFlags?: LDFlagSet,
 ): Promise<AllFlagsLDClient> => {
-  const allOptions = { wrapperName: 'react-client-sdk', wrapperVersion: version, ...options };
+  const allOptions = { wrapperName: 'react-client-sdk', wrapperVersion: packageInfo.version, ...options };
   const ldClient = ldClientInitialize(clientSideID, user, allOptions);
 
   return new Promise<AllFlagsLDClient>((resolve) => {


### PR DESCRIPTION
**Requirements**

- [x] I have added test coverage for new or changed functionality
- [x] I have followed the repository's [pull request submission guidelines](../blob/master/CONTRIBUTING.md#submitting-pull-requests)
- [x] I have validated my changes against all supported platform versions

**Related issues**

#146, since this error pops up when compiling react-client-sdk with newest TypeScript

**Describe the solution you've provided**

Fixes TypeScript warning:

```
WARNING in …

Should not import the named export 'version' (imported as 'version') from default-exporting module (only default export is available soon)
```

**Describe alternatives you've considered**

Manually applying patch on our repository; doesn't seem like a sustainable idea.
