### PR TITLE
Allow users to create type-safe/strictly typed feature flags with useFlags

### DIFF
--- a/src/useFlags.ts
+++ b/src/useFlags.ts
@@ -10,10 +10,10 @@ import context, { LDContext } from './context';
  *
  * @return All the feature flags configured in your LaunchDarkly project
  */
-const useFlags = <T extends LDFlagSet = LDFlagSet>(): T => {
+function useFlags<T extends Record<string, any> = LDFlagSet>(): T {
   const { flags } = useContext<LDContext>(context);
 
   return flags as T;
-};
+}
 
 export default useFlags;


### PR DESCRIPTION
**Requirements**

- [ ] I have added test coverage for new or changed functionality
  - [X] This is typing-only
- [X] I have followed the repository's [pull request submission guidelines](../blob/main/CONTRIBUTING.md#submitting-pull-requests)
- [X] I have validated my changes against all supported platform versions

**Related issues**

#139, https://github.com/launchdarkly/js-sdk-common/issues/32

**Describe the solution you've provided**

This MR updates `useFlags` generics and definition to allow implementing codebases to specify their own strictly typed feature flag interface.

```typescript
// Before
declare const useFlags: <T extends LDFlagSet = LDFlagSet>() => T;

// After
declare function useFlags<T extends Record<string, any> = LDFlagSet>(): T;
```

By declaring `useFlags` as `const` and not a `function` it is not possible to overload its definition. [Function overloads](https://www.typescriptlang.org/docs/handbook/2/functions.html#function-overloads) allow implementing codebases to re-declare `useFlags` to be more strict.

Additionally, currently the generic on `useFlags` is set to `extends LDFlagSet`, but this is not necessarily true. When `useCamelCaseFlagKeys` is `true`, the return value from `useFlags` can differ from `LDFlagSet` if `LDFlagSet` has been augmented for the client.

**Describe alternatives you've considered**

Open to alternatives, in our codebase we've considered writing a wrapping function.

**Additional context**

Example codebase implementation using these changes:

```typescript
declare module 'launchdarkly-js-sdk-common' {
    export interface LDFlagSet {
        'show-a-cool-feature': boolean;
        'demonstrate-another-cool-number': number;
    }
}

const ldClient = initialize(
    getClientSideID(),
    { anonymous: true },
    {
        allAttributesPrivate: true,
        sendEvents: true,
    },
);


// ldClient.allFlags()['demonstrate-another-cool-number']

export interface CamelCaseFeatureFlags {
    showACoolFeature: boolean;
    demonstrateAnotherCoolNumber: number;
}

declare module 'launchdarkly-react-client-sdk' {
    export function useFlags(): CamelCaseFeatureFlags;
}

export const LaunchDarklyProvider: React.FC<unknown> = props => {
    return (
        <LDProvider
            clientSideID={getClientSideID()}
            ldClient={ldClient}
            reactOptions={{
                useCamelCaseFlagKeys: true,
            }}
            options={{
                // bootstrap: defaultFeatureFlags,
            }}
        >
            {props.children}
        </LDProvider>
    );
};

```
