### PR TITLE
check if the original flags object has the flag, not just the camelca…

### DIFF
--- a/src/getFlagsProxy.test.ts
+++ b/src/getFlagsProxy.test.ts
@@ -45,8 +45,7 @@ test('proxy calls ldClient.variation on flag read', () => {
 });
 
 test('proxy calls ldClient.variation on flag read when not using camel case keys', () => {
-  const { flags } = getFlagsProxy(ldClient, rawFlags,
-  { useCamelCaseFlagKeys: false, sendEventsOnFlagRead: true });
+  const { flags } = getFlagsProxy(ldClient, rawFlags, { useCamelCaseFlagKeys: false, sendEventsOnFlagRead: true });
 
   expect(flags['foo-bar']).toBe('foobar');
   expect(ldClient.variation).toHaveBeenCalledWith('foo-bar', 'foobar');

--- a/src/getFlagsProxy.test.ts
+++ b/src/getFlagsProxy.test.ts
@@ -52,7 +52,6 @@ test('proxy calls ldClient.variation on flag read when not using camel case keys
   expect(ldClient.variation).toHaveBeenCalledWith('foo-bar', 'foobar');
 });
 
-
 test('returns flag key map', () => {
   const { flagKeyMap } = getFlagsProxy(ldClient, rawFlags);
 

--- a/src/getFlagsProxy.test.ts
+++ b/src/getFlagsProxy.test.ts
@@ -48,8 +48,7 @@ test('proxy calls ldClient.variation on flag read when not using camel case keys
   const { flags } = getFlagsProxy(ldClient, rawFlags,
   { useCamelCaseFlagKeys: false, sendEventsOnFlagRead: true });
 
-  expect(flags["foo-bar"]).toBe('foobar');
-
+  expect(flags['foo-bar']).toBe('foobar');
   expect(ldClient.variation).toHaveBeenCalledWith('foo-bar', 'foobar');
 });
 

--- a/src/getFlagsProxy.test.ts
+++ b/src/getFlagsProxy.test.ts
@@ -45,9 +45,10 @@ test('proxy calls ldClient.variation on flag read', () => {
 });
 
 test('proxy calls ldClient.variation on flag read when not using camel case keys', () => {
-  const { flags } = getFlagsProxy(ldClient, rawFlags, { useCamelCaseFlagKeys: false });
+  const { flags } = getFlagsProxy(ldClient, rawFlags,
+  { useCamelCaseFlagKeys: false, sendEventsOnFlagRead: true });
 
-  expect(flags.fooBar).toBe('foobar');
+  expect(flags["foo-bar"]).toBe('foobar');
 
   expect(ldClient.variation).toHaveBeenCalledWith('foo-bar', 'foobar');
 });

--- a/src/getFlagsProxy.test.ts
+++ b/src/getFlagsProxy.test.ts
@@ -44,6 +44,15 @@ test('proxy calls ldClient.variation on flag read', () => {
   expect(ldClient.variation).toHaveBeenCalledWith('foo-bar', 'foobar');
 });
 
+test('proxy calls ldClient.variation on flag read when not using camel case keys', () => {
+  const { flags } = getFlagsProxy(ldClient, rawFlags, { useCamelCaseFlagKeys: false });
+
+  expect(flags.fooBar).toBe('foobar');
+
+  expect(ldClient.variation).toHaveBeenCalledWith('foo-bar', 'foobar');
+});
+
+
 test('returns flag key map', () => {
   const { flagKeyMap } = getFlagsProxy(ldClient, rawFlags);
 

--- a/src/getFlagsProxy.ts
+++ b/src/getFlagsProxy.ts
@@ -64,7 +64,8 @@ function toFlagsProxy(ldClient: LDClient, flags: LDFlagSet, flagKeyMap: LDFlagKe
         return currentValue;
       }
 
-      let flagName = hasFlag(flagKeyMap, prop) ? flagKeyMap[prop] : prop;
+      // check camelized map first before just using passed-in prop
+      const flagName = hasFlag(flagKeyMap, prop) ? flagKeyMap[prop] : prop;
 
       if (currentValue === undefined) {
         return;

--- a/src/getFlagsProxy.ts
+++ b/src/getFlagsProxy.ts
@@ -60,7 +60,7 @@ function toFlagsProxy(ldClient: LDClient, flags: LDFlagSet, flagKeyMap: LDFlagKe
       const currentValue = Reflect.get(target, prop, receiver);
 
       // only process flag keys and ignore symbols and native Object functions
-      if (typeof prop === 'symbol' || !hasFlag(flagKeyMap, prop)) {
+      if (typeof prop === 'symbol' || (!hasFlag(flags, prop) && !hasFlag(flagKeyMap, prop)) {
         return currentValue;
       }
 

--- a/src/getFlagsProxy.ts
+++ b/src/getFlagsProxy.ts
@@ -60,7 +60,7 @@ function toFlagsProxy(ldClient: LDClient, flags: LDFlagSet, flagKeyMap: LDFlagKe
       const currentValue = Reflect.get(target, prop, receiver);
 
       // only process flag keys and ignore symbols and native Object functions
-      if (typeof prop === 'symbol' || (!hasFlag(flags, prop) && !hasFlag(flagKeyMap, prop)) {
+      if (typeof prop === 'symbol' || (!hasFlag(flags, prop) && !hasFlag(flagKeyMap, prop))) {
         return currentValue;
       }
 

--- a/src/getFlagsProxy.ts
+++ b/src/getFlagsProxy.ts
@@ -64,11 +64,13 @@ function toFlagsProxy(ldClient: LDClient, flags: LDFlagSet, flagKeyMap: LDFlagKe
         return currentValue;
       }
 
+      let flagName = hasFlag(flagKeyMap, prop) ? flagKeyMap[prop] : prop;
+
       if (currentValue === undefined) {
         return;
       }
 
-      return ldClient.variation(flagKeyMap[prop], currentValue);
+      return ldClient.variation(flagName, currentValue);
     },
   });
 }


### PR DESCRIPTION
…sed keys map

**Requirements**

- [x] I have added test coverage for new or changed functionality
- [x] I have followed the repository's [pull request submission guidelines](../blob/main/CONTRIBUTING.md#submitting-pull-requests)
- [ ] I have validated my changes against all supported platform versions

**Related issues**

https://github.com/launchdarkly/react-client-sdk/issues/180

**Describe the solution you've provided**

When checking to see if the flag is contained in the set of available flags, don't just check the `flagKeyMap` which is only available if camelCaseKeys are used; also check the original flag keys and if the key is in there, continue on to `variation()`.

**Describe alternatives you've considered**

Provide a clear and concise description of any alternative solutions or features you've considered.

**Additional context**

Add any other context about the pull request here.
