### PR TITLE
prepare 3.0.2 release

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
   },
   "dependencies": {
     "hoist-non-react-statics": "^3.3.2",
-    "launchdarkly-js-client-sdk": "^3.0.0",
+    "launchdarkly-js-client-sdk": "^3.1.1",
     "lodash.camelcase": "^4.3.0"
   },
   "peerDependencies": {


### PR DESCRIPTION
## [3.0.2] - 2023-02-15
### Changed:
- Upgrade to `js-client-sdk` version `3.1.1`. This removes usage of optional chaining (`?.`) to allow for use with older transpilers.