### PR TITLE
Add parcel to reduce the bundle size

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .DS_Store
+.parcel-cache
 **/junit.xml
 npm-debug.log
 yarn-error.log

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ test-types.js
 docs/build/
 yarn.lock
 package-lock.json
+.npmrc

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "launchdarkly-react-client-sdk",
+  "browserslist": ["last 2 versions", "ie >= 11"],
   "version": "3.0.3",
   "description": "LaunchDarkly SDK for React",
   "author": "LaunchDarkly <team@launchdarkly.com>",
@@ -12,8 +13,9 @@
     "sdk",
     "bindings"
   ],
-  "main": "lib/index.js",
-  "types": "lib/index.d.ts",
+  "source": "src/index.ts",
+  "main": "dist/main.js",
+  "types": "dist/index.d.ts",
   "files": [
     "lib",
     "src",
@@ -23,7 +25,7 @@
   "scripts": {
     "test": "jest",
     "test:junit": "jest --ci --reporters=default --reporters=jest-junit",
-    "build": "rimraf lib/* && tsc && mv lib/src/* lib && rimraf lib/package.json lib/src lib/*.test.*",
+    "build": "parcel build",
     "lint": "tslint -p tsconfig.json 'src/**/*.ts*'",
     "lint:all": "npm run lint",
     "check-typescript": "tsc",
@@ -38,6 +40,8 @@
   },
   "homepage": "https://github.com/launchdarkly/react-client-sdk",
   "devDependencies": {
+    "@parcel/packager-ts": "2.8.3",
+    "@parcel/transformer-typescript-types": "2.8.3",
     "@testing-library/jest-dom": "^5.16.4",
     "@testing-library/react": "^13.0.1",
     "@types/hoist-non-react-statics": "^3.3.1",
@@ -51,10 +55,9 @@
     "jest-environment-jsdom": "^27.4.4",
     "jest-environment-jsdom-global": "^3.0.0",
     "jest-junit": "^13.0.0",
+    "parcel": "^2.8.3",
     "prettier": "^1.18.2",
     "prop-types": "^15.7.2",
-    "react": "^18.0.0",
-    "react-dom": "^18.0.0",
     "react-test-renderer": "^18.0.0",
     "rimraf": "^3.0.0",
     "ts-jest": "^27.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,5 @@
 {
   "name": "launchdarkly-react-client-sdk",
-  "browserslist": ["last 2 versions", "ie >= 11"],
   "version": "3.0.3",
   "description": "LaunchDarkly SDK for React",
   "author": "LaunchDarkly <team@launchdarkly.com>",
@@ -26,6 +25,7 @@
     "test": "jest",
     "test:junit": "jest --ci --reporters=default --reporters=jest-junit",
     "build": "parcel build",
+    "build:analyze": "parcel build --reporter @parcel/reporter-bundle-analyzer",
     "lint": "tslint -p tsconfig.json 'src/**/*.ts*'",
     "lint:all": "npm run lint",
     "check-typescript": "tsc",
@@ -41,6 +41,7 @@
   "homepage": "https://github.com/launchdarkly/react-client-sdk",
   "devDependencies": {
     "@parcel/packager-ts": "2.8.3",
+    "@parcel/reporter-bundle-analyzer": "^2.8.3",
     "@parcel/transformer-typescript-types": "2.8.3",
     "@testing-library/jest-dom": "^5.16.4",
     "@testing-library/react": "^13.0.1",
@@ -67,6 +68,7 @@
     "typescript": "^4.5.3"
   },
   "dependencies": {
+    "@swc/helpers": "^0.4.14",
     "hoist-non-react-statics": "^3.3.2",
     "launchdarkly-js-client-sdk": "^3.1.1",
     "lodash.camelcase": "^4.3.0"
@@ -74,5 +76,19 @@
   "peerDependencies": {
     "react": "^16.6.3 || ^17.0.0 || ^18.0.0",
     "react-dom": "^16.8.4 || ^17.0.0 || ^18.0.0"
+  },
+  "targets": {
+    "main": {
+      "context": "browser",
+      "outputFormat": "commonjs",
+      "isLibrary": true,
+      "optimize": true,
+      "engines": {
+        "browsers": [
+          "> 0.5%, last 2 versions, not dead",
+          "ie >= 11"
+        ]
+      }
+    }
   }
 }


### PR DESCRIPTION
**Requirements**

- [x] I have added test coverage for new or changed functionality
- [x] I have followed the repository's [pull request submission guidelines](../blob/main/CONTRIBUTING.md#submitting-pull-requests)
- [x] I have validated my changes against all supported platform versions

**Related issues**

Currently, we are integrating launch darkly for Customer but I do not want to add 75kb and 496ms download time for all SLOW 3G which is typical in Germany in on rural region.

More than 30kb I find extremely heavy for a flag management tool our GTM have 35 KB with all our 3rd libraries.
So, the Bundlesize and Lighthouse impact is a showstopper for me to integrate into the frontend.
There will be 75kb JavaScript evaluated and this libary will cost 2-3 points in the Lighthouse Score.


**Describe the solution you've provided**

Use parcle to reduce the bundle size also schould allow to use it shakeable. 
<img width="1392" alt="image" src="https://user-images.githubusercontent.com/5289370/225967296-fcfc20d4-f978-43c4-b340-3da28f185bb1.png">


**Describe alternatives you've considered**

Provide a clear and concise description of any alternative solutions or features you've considered.

**Additional context**

Add any other context about the pull request here.
