### PR TITLE
prepare 3.0.4 release

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
   },
   "dependencies": {
     "hoist-non-react-statics": "^3.3.2",
-    "launchdarkly-js-client-sdk": "^3.1.1",
+    "launchdarkly-js-client-sdk": "^3.1.2",
     "lodash.camelcase": "^4.3.0"
   },
   "peerDependencies": {


### PR DESCRIPTION
## [3.0.4] - 2023-03-21
### Changed:
- Update `LDContext` to allow for key to be optional. This is used when making an anonymous context with a generated key.