### PR TITLE
feat: allow bootstraped flags to be used even if client fails to init

### DIFF
--- a/src/provider.tsx
+++ b/src/provider.tsx
@@ -77,15 +77,17 @@ class LDProvider extends Component<PropsWithChildren<ProviderConfig>, LDHocState
     const { clientSideID, flags, options } = this.props;
     let ldClient = await this.props.ldClient;
     const reactOptions = this.getReactOptions();
-    let unproxiedFlags;
+    let unproxiedFlags = this.state.unproxiedFlags;
     let error: Error | undefined;
     if (ldClient) {
       unproxiedFlags = fetchFlags(ldClient, flags);
     } else {
       const initialisedOutput = await initLDClient(clientSideID, getContextOrUser(this.props), options, flags);
-      unproxiedFlags = initialisedOutput.flags;
-      ldClient = initialisedOutput.ldClient;
       error = initialisedOutput.error;
+      if (!error) {
+        unproxiedFlags = initialisedOutput.flags;
+      }
+      ldClient = initialisedOutput.ldClient;
     }
     this.setState({ unproxiedFlags, ...getFlagsProxy(ldClient, unproxiedFlags, reactOptions, flags), ldClient, error });
     this.subscribeToChanges(ldClient);


### PR DESCRIPTION
**Requirements**

- [ ] I have added test coverage for new or changed functionality
- [ ] I have followed the repository's [pull request submission guidelines](../blob/main/CONTRIBUTING.md#submitting-pull-requests)
- [ ] I have validated my changes against all supported platform versions

**Related issues**

https://github.com/launchdarkly/react-client-sdk/issues/152

**Describe the solution you've provided**

This solution just maintains any flags that were bootstrapped, in the event of an error while initializing the client (as is the case when I don't use any `clientSideId` locally)

**Describe alternatives you've considered**

The alternative would be a proper offline-mode implementation that was requested already in https://github.com/launchdarkly/react-client-sdk/issues/152

**Additional context**

currently using this as a patch (to be used with [patch-package](https://www.npmjs.com/package/patch-package), add `patches/launchdarkly-react-client-sdk+3.0.6.patch`):

```
diff --git a/node_modules/launchdarkly-react-client-sdk/lib/provider.js b/node_modules/launchdarkly-react-client-sdk/lib/provider.js
index c4f17b2..e901bb6 100644
--- a/node_modules/launchdarkly-react-client-sdk/lib/provider.js
+++ b/node_modules/launchdarkly-react-client-sdk/lib/provider.js
@@ -73,16 +73,18 @@ class LDProvider extends react_1.Component {
             const { clientSideID, flags, options } = this.props;
             let ldClient = yield this.props.ldClient;
             const reactOptions = this.getReactOptions();
-            let unproxiedFlags;
+            let unproxiedFlags = this.state.unproxiedFlags;
             let error;
             if (ldClient) {
                 unproxiedFlags = (0, utils_1.fetchFlags)(ldClient, flags);
             }
             else {
                 const initialisedOutput = yield (0, initLDClient_1.default)(clientSideID, (0, utils_1.getContextOrUser)(this.props), options, flags);
-                unproxiedFlags = initialisedOutput.flags;
-                ldClient = initialisedOutput.ldClient;
                 error = initialisedOutput.error;
+                if(!error) {
+                    unproxiedFlags = initialisedOutput.flags;
+                }
+                ldClient = initialisedOutput.ldClient;
             }
             this.setState(Object.assign(Object.assign({ unproxiedFlags }, (0, getFlagsProxy_1.default)(ldClient, unproxiedFlags, reactOptions, flags)), { ldClient, error }));
             this.subscribeToChanges(ldClient);

```
