### PR TITLE
prepare 3.0.7 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the LaunchDarkly Client-side SDK for React will be documented in this file. For the source code for versions 2.13.0 and earlier, see the corresponding tags in the [js-client-sdk](https://github.com/launchdarkly/js-client-sdk) repository; this code was previously in a monorepo package there. See also the [JavaScript SDK changelog](https://github.com/launchdarkly/js-client-sdk/blob/main/CHANGELOG.md), since the React SDK inherits all of the underlying functionality of the JavaScript SDK; this file covers only changes that are specific to the React interface. This project adheres to [Semantic Versioning](http://semver.org).
 
+## [3.0.6] - 2023-04-12
+### Fixed:
+- Rolled back parcel due to erroneous types being generated issue [197](https://github.com/launchdarkly/react-client-sdk/issues/197).
+
 ## [3.0.5] - 2023-04-12
 ### Added:
 - Use parcel to reduce the bundle size.

--- a/docs/typedoc.js
+++ b/docs/typedoc.js
@@ -1,10 +1,16 @@
+let version = process.env.VERSION;
+if (!version) {
+  const package = require('../package.json');
+  version = package.version;
+}
+
 module.exports = {
   out: '/tmp/project-releaser/project/docs/build/html',
   exclude: [
     '**/node_modules/**',
     'test-types.ts'
   ],
-  name: "LaunchDarkly React SDK (2.25.0)",
+  name: `LaunchDarkly React SDK (${version})`,
   readme: 'none',                // don't add a home page with a copy of README.md
   entryPoints: "/tmp/project-releaser/project/src/index.ts",
   entryPointStrategy: "expand"

--- a/examples/typescript/.gitignore
+++ b/examples/typescript/.gitignore
@@ -21,5 +21,3 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
-
-public

--- a/examples/typescript/package.json
+++ b/examples/typescript/package.json
@@ -22,7 +22,9 @@
     "start": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
-    "eject": "react-scripts eject"
+    "eject": "react-scripts eject",
+    "postinstall": "cd ../../ && yarn link-dev",
+    "tsc": "tsc"
   },
   "eslintConfig": {
     "extends": [

--- a/examples/typescript/public/index.html
+++ b/examples/typescript/public/index.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang='en'>
+<head>
+  <meta charset='UTF-8'>
+  <title>Title</title>
+</head>
+<body>
+<div id="root"></div>
+</body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "launchdarkly-react-client-sdk",
-  "version": "3.0.5",
+  "version": "3.0.6",
   "description": "LaunchDarkly SDK for React",
   "author": "LaunchDarkly <team@launchdarkly.com>",
   "license": "Apache-2.0",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,11 @@
     "sdk",
     "bindings"
   ],
-  "main": "lib/index.js",
+  "exports": {
+    "require": "./lib/cjs/index.js",
+    "import": "./lib/esm/index.js"
+  },
+  "main": "./lib/cjs/index.js",
   "types": "lib/index.d.ts",
   "files": [
     "lib",
@@ -23,7 +27,10 @@
   "scripts": {
     "test": "jest",
     "test:junit": "jest --ci --reporters=default --reporters=jest-junit",
-    "build": "rimraf lib/* && tsc && mv lib/src/* lib && rimraf lib/package.json lib/src lib/*.test.*",
+    "clean": "rimraf lib/*",
+    "rb": "rollup -c --configPlugin typescript",
+    "rbw": "yarn rb --watch",
+    "build": "yarn clean && yarn rb",
     "lint": "tslint -p tsconfig.json 'src/**/*.ts*'",
     "lint:all": "npm run lint",
     "check-typescript": "tsc",
@@ -38,6 +45,10 @@
   },
   "homepage": "https://github.com/launchdarkly/react-client-sdk",
   "devDependencies": {
+    "@rollup/plugin-json": "^6.0.0",
+    "@rollup/plugin-node-resolve": "^15.1.0",
+    "@rollup/plugin-terser": "^0.4.3",
+    "@rollup/plugin-typescript": "^11.1.2",
     "@testing-library/jest-dom": "^5.16.4",
     "@testing-library/react": "^13.0.1",
     "@types/hoist-non-react-statics": "^3.3.1",
@@ -47,6 +58,7 @@
     "@types/react": "^18.0.3",
     "@types/react-dom": "^18.0.0",
     "@types/react-test-renderer": "^18.0.0",
+    "esbuild": "^0.18.11",
     "jest": "^27.4.4",
     "jest-environment-jsdom": "^27.4.4",
     "jest-environment-jsdom-global": "^3.0.0",
@@ -57,6 +69,10 @@
     "react-dom": "^18.0.0",
     "react-test-renderer": "^18.0.0",
     "rimraf": "^3.0.0",
+    "rollup": "^3.26.2",
+    "rollup-plugin-dts": "^5.3.0",
+    "rollup-plugin-esbuild": "^5.0.0",
+    "rollup-plugin-filesize": "^10.0.0",
     "ts-jest": "^27.1.1",
     "tslint": "^6.1.3",
     "tslint-config-prettier": "^1.18.0",

--- a/rollup.config.ts
+++ b/rollup.config.ts
@@ -1,0 +1,44 @@
+import dts from 'rollup-plugin-dts';
+import esbuild from 'rollup-plugin-esbuild';
+import filesize from 'rollup-plugin-filesize';
+import json from '@rollup/plugin-json';
+import resolve from '@rollup/plugin-node-resolve';
+import terser from '@rollup/plugin-terser';
+
+const plugins = [resolve(), esbuild(), json(), terser(), filesize()];
+const external = /node_modules/;
+
+export default [
+  {
+    input: 'src/index.ts',
+    output: [
+      {
+        file: 'lib/cjs/index.js',
+        format: 'cjs',
+        sourcemap: true,
+      },
+    ],
+    plugins,
+    external,
+  },
+  {
+    input: 'src/index.ts',
+    output: [
+      {
+        file: 'lib/esm/index.js',
+        format: 'esm',
+        sourcemap: true,
+      },
+    ],
+    plugins,
+    external,
+  },
+  {
+    input: 'src/index.ts',
+    plugins: [dts(), json()],
+    output: {
+      file: 'lib/index.d.ts',
+      format: 'es',
+    },
+  },
+];

--- a/src/initLDClient.ts
+++ b/src/initLDClient.ts
@@ -15,7 +15,7 @@ const wrapperOptions: LDOptions = {
  * @param clientSideID Your project and environment specific client side ID
  * @param context A LaunchDarkly context object
  * @param options LaunchDarkly initialization options
- * @param targetFlags If specified, `launchdarkly-react-client-sdk` will only request and listen to these flags.
+ * @param targetFlags If specified, `launchdarkly-react-client-sdk` will only listen for changes to these flags.
  * Flag keys must be in their original form as known to LaunchDarkly rather than in their camel-cased form.
  *
  * @see `ProviderConfig` for more details about the parameters

--- a/src/types.ts
+++ b/src/types.ts
@@ -78,7 +78,7 @@ export interface ProviderConfig {
   reactOptions?: LDReactOptions;
 
   /**
-   * If specified, `launchdarkly-react-client-sdk` will only request and listen to these flags.
+   * If specified, `launchdarkly-react-client-sdk` will only listen for changes to these flags.
    * Otherwise, all flags will be requested and listened to.
    * Flag keys must be in their original form as known to LaunchDarkly rather than in their camel-cased form.
    */

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -54,7 +54,7 @@ export const getFlattenedFlagsFromChangeset = (
  * Retrieves flag values.
  *
  * @param ldClient LaunchDarkly client
- * @param targetFlags If specified, `launchdarkly-react-client-sdk` will only request and listen to these flags.
+ * @param targetFlags If specified, `launchdarkly-react-client-sdk` will only listen for changes to these flags.
  * Flag keys must be in their original form as known to LaunchDarkly rather than in their camel-cased form.
  *
  * @returns an `LDFlagSet` with the current flag values from LaunchDarkly filtered by `targetFlags`.


### PR DESCRIPTION
## [3.0.7] - 2023-07-11
### Changed:
- This release introduces rollup to bundle the build output. The bundle is minified and supports both cjs and esm.