### PR TITLE
prepare 3.0.8 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the LaunchDarkly Client-side SDK for React will be documented in this file. For the source code for versions 2.13.0 and earlier, see the corresponding tags in the [js-client-sdk](https://github.com/launchdarkly/js-client-sdk) repository; this code was previously in a monorepo package there. See also the [JavaScript SDK changelog](https://github.com/launchdarkly/js-client-sdk/blob/main/CHANGELOG.md), since the React SDK inherits all of the underlying functionality of the JavaScript SDK; this file covers only changes that are specific to the React interface. This project adheres to [Semantic Versioning](http://semver.org).
 
+## [3.0.7] - 2023-07-12
+### Changed:
+- This release introduces rollup to bundle the build output. The bundle is minified and supports both cjs and esm.
+
 ## [3.0.6] - 2023-04-12
 ### Fixed:
 - Rolled back parcel due to erroneous types being generated issue [197](https://github.com/launchdarkly/react-client-sdk/issues/197).

--- a/package.json
+++ b/package.json
@@ -13,11 +13,12 @@
     "bindings"
   ],
   "exports": {
+    "types": "./lib/index.d.ts",
     "require": "./lib/cjs/index.js",
     "import": "./lib/esm/index.js"
   },
   "main": "./lib/cjs/index.js",
-  "types": "lib/index.d.ts",
+  "types": "./lib/index.d.ts",
   "files": [
     "lib",
     "src",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "launchdarkly-react-client-sdk",
-  "version": "3.0.6",
+  "version": "3.0.7",
   "description": "LaunchDarkly SDK for React",
   "author": "LaunchDarkly <team@launchdarkly.com>",
   "license": "Apache-2.0",


### PR DESCRIPTION
## [3.0.8] - 2023-07-14
### Fixed:
- #202 Use bootstrap values if there's an error initializing the client.
- #208 Add `types` to `exports` field in package.json to fix typescript compilation error when using `moduleResolution: bundler`.