### PR TITLE
prepare 3.0.9 release

### DIFF
--- a/examples/async-provider/yarn.lock
+++ b/examples/async-provider/yarn.lock
@@ -7179,9 +7179,9 @@ which@^2.0.1:
     isexe "^2.0.0"
 
 word-wrap@~1.2.3:
-  version "1.2.3"
-  resolved "https://registry.yarnpkg.com/word-wrap/-/word-wrap-1.2.3.tgz#610636f6b1f703891bd34771ccb17fb93b47079c"
-  integrity sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/word-wrap/-/word-wrap-1.2.4.tgz#cb4b50ec9aca570abd1f52f33cd45b6c61739a9f"
+  integrity sha512-2V81OA4ugVo5pRo46hAoD2ivUJx8jXmWXfUkY4KFNw0hEptvN0QfH3K4nHiwzGeKl5rFKedV48QVoqYavy4YpA==
 
 worker-farm@^1.7.0:
   version "1.7.0"

--- a/examples/hoc/yarn.lock
+++ b/examples/hoc/yarn.lock
@@ -7508,9 +7508,9 @@ widest-line@^2.0.0:
     string-width "^2.1.1"
 
 word-wrap@~1.2.3:
-  version "1.2.3"
-  resolved "https://registry.yarnpkg.com/word-wrap/-/word-wrap-1.2.3.tgz#610636f6b1f703891bd34771ccb17fb93b47079c"
-  integrity sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/word-wrap/-/word-wrap-1.2.4.tgz#cb4b50ec9aca570abd1f52f33cd45b6c61739a9f"
+  integrity sha512-2V81OA4ugVo5pRo46hAoD2ivUJx8jXmWXfUkY4KFNw0hEptvN0QfH3K4nHiwzGeKl5rFKedV48QVoqYavy4YpA==
 
 worker-farm@^1.7.0:
   version "1.7.0"

--- a/examples/typescript/package.json
+++ b/examples/typescript/package.json
@@ -10,7 +10,7 @@
     "@types/node": "^16.18.18",
     "@types/react": "^18.0.28",
     "@types/react-dom": "^18.0.11",
-    "launchdarkly-react-client-sdk": "^3.0.4",
+    "launchdarkly-react-client-sdk": "^3.0.8",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-scripts": "5.0.1",

--- a/examples/typescript/src/index.tsx
+++ b/examples/typescript/src/index.tsx
@@ -3,13 +3,19 @@ import ReactDOM from 'react-dom/client';
 import './index.css';
 import App from './App';
 import reportWebVitals from './reportWebVitals';
-import { asyncWithLDProvider } from 'launchdarkly-react-client-sdk';
+import { asyncWithLDProvider, LDContext } from 'launchdarkly-react-client-sdk';
 
 (async () => {
   // Set clientSideID to your own Client-side ID. You can find this in
   // your LaunchDarkly portal under Account settings / Projects
+  const context: LDContext = {
+    kind: 'user',
+    key: 'test-user-1',
+  };
+
   const LDProvider = await asyncWithLDProvider({
-    clientSideID: process.env.REACT_APP_LD_CLIENT_SIDE_ID ?? '',
+    clientSideID: process.env.REACT_APP_LD_CLIENT_SIDE_ID ?? '59b2b2596d1a250b1c78baa4',
+    context,
   });
 
   const root = ReactDOM.createRoot(document.getElementById('root') as HTMLElement);

--- a/examples/typescript/src/index.tsx
+++ b/examples/typescript/src/index.tsx
@@ -14,7 +14,7 @@ import { asyncWithLDProvider, LDContext } from 'launchdarkly-react-client-sdk';
   };
 
   const LDProvider = await asyncWithLDProvider({
-    clientSideID: process.env.REACT_APP_LD_CLIENT_SIDE_ID ?? '59b2b2596d1a250b1c78baa4',
+    clientSideID: process.env.REACT_APP_LD_CLIENT_SIDE_ID ?? '',
     context,
   });
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -146,3 +146,5 @@ export interface AllFlagsLDClient {
 export interface LDFlagKeyMap {
   [camelCasedKey: string]: string;
 }
+
+export * from 'launchdarkly-js-client-sdk';


### PR DESCRIPTION
## [3.0.9] - 2023-08-21
### Fixed:
- Types from the js client sdk are now re-exported in the react sdk there's no need to separately install the js sdk just for types.