### PR TITLE
prepare 3.1.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to the LaunchDarkly Client-side SDK for React will be documented in this file. For the source code for versions 2.13.0 and earlier, see the corresponding tags in the [js-client-sdk](https://github.com/launchdarkly/js-client-sdk) repository; this code was previously in a monorepo package there. See also the [JavaScript SDK changelog](https://github.com/launchdarkly/js-client-sdk/blob/main/CHANGELOG.md), since the React SDK inherits all of the underlying functionality of the JavaScript SDK; this file covers only changes that are specific to the React interface. This project adheres to [Semantic Versioning](http://semver.org).
 
+## [3.0.10] - 2023-12-11
+### Fixed:
+- Added deferred initialization example.
+- Fixes #228. Bumped js sdk dependency.
+
 ## [3.0.9] - 2023-08-21
 ### Fixed:
 - Types from the js client sdk are now re-exported in the react sdk there's no need to separately install the js sdk just for types.

--- a/examples/async-provider/package.json
+++ b/examples/async-provider/package.json
@@ -4,7 +4,7 @@
   "description": "Example usage of launchdarkly-react-client-sdk",
   "main": "src/server/index.js",
   "scripts": {
-    "start": "node src/server/index.js",
+    "start": "NODE_OPTIONS=--openssl-legacy-provider node src/server/index.js",
     "lint": "eslint ./src",
     "serve": "webpack-serve webpack.config.server",
     "postinstall": "cd ../../ && yarn link-dev"
@@ -27,11 +27,11 @@
   "dependencies": {
     "@babel/polyfill": "^7.2.5",
     "express": "^4.17.3",
-    "launchdarkly-react-client-sdk": "^3.0.0-alpha.1",
+    "launchdarkly-react-client-sdk": "^3.0.10",
     "lodash": "^4.17.21",
     "prop-types": "^15.7.2",
-    "react": "^16.11.0",
-    "react-dom": "^16.11.0",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
     "react-router-dom": "^5.1.2",
     "styled-components": "^4.1.3"
   },

--- a/examples/async-provider/src/client/index.js
+++ b/examples/async-provider/src/client/index.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render } from 'react-dom';
+import { createRoot } from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom';
 import { asyncWithLDProvider } from 'launchdarkly-react-client-sdk';
 import App from '../universal/app';
@@ -9,12 +9,11 @@ import App from '../universal/app';
   // your LaunchDarkly portal under Account settings / Projects
   const LDProvider = await asyncWithLDProvider({ clientSideID: '' });
 
-  render(
+  const root = createRoot(document.getElementById('reactDiv'));
+  root.render(
     <BrowserRouter>
       <LDProvider>
         <App />
       </LDProvider>
-    </BrowserRouter>,
-    document.getElementById('reactDiv'),
-  );
+    </BrowserRouter>);
 })();

--- a/examples/async-provider/yarn.lock
+++ b/examples/async-provider/yarn.lock
@@ -4508,30 +4508,30 @@ language-tags@^1.0.5:
   dependencies:
     language-subtag-registry "~0.3.2"
 
-launchdarkly-js-client-sdk@^3.0.0-alpha.3:
-  version "3.0.0-alpha.4"
-  resolved "https://registry.yarnpkg.com/launchdarkly-js-client-sdk/-/launchdarkly-js-client-sdk-3.0.0-alpha.4.tgz#fcea9bc37e05bb2a3373a4cddf1df7c6101edbd4"
-  integrity sha512-tJXCEx/8bwBTL+PbWHiP2QOgQ3kj4w5XS2nD1GlD6Mbm13o7lXabAQLCMpIfSytFErbBU7OuoS9+rOSPegwYeg==
+launchdarkly-js-client-sdk@^3.1.4:
+  version "3.1.4"
+  resolved "https://registry.yarnpkg.com/launchdarkly-js-client-sdk/-/launchdarkly-js-client-sdk-3.1.4.tgz#e613cb53412533c07ccf140ae570fc994c59758d"
+  integrity sha512-yq0FeklpVuHMSRz7jfUAfyM7I/659RvGztqJ0Y9G5eN/ZrG1o2W61ZU0Nrv/gqZCtLXjarh/u1otxSFFBjTpHw==
   dependencies:
     escape-string-regexp "^4.0.0"
-    launchdarkly-js-sdk-common "5.0.0-alpha.5"
+    launchdarkly-js-sdk-common "5.0.3"
 
-launchdarkly-js-sdk-common@5.0.0-alpha.5:
-  version "5.0.0-alpha.5"
-  resolved "https://registry.yarnpkg.com/launchdarkly-js-sdk-common/-/launchdarkly-js-sdk-common-5.0.0-alpha.5.tgz#52fe835ad4c51e2579a3bcd6af2012a2e424280a"
-  integrity sha512-YvPAMm/El6y9pCv3yEVZy0ck5R1FRyoqjMUYRxOo73z/wqmMXuRVOY5KQMmnM6Sqvhv0lanSJK77oIpMyj0IZw==
+launchdarkly-js-sdk-common@5.0.3:
+  version "5.0.3"
+  resolved "https://registry.yarnpkg.com/launchdarkly-js-sdk-common/-/launchdarkly-js-sdk-common-5.0.3.tgz#345f899f5779be8b03d6599978c855eb838d8b7f"
+  integrity sha512-wKG8UsVbPVq8+7eavgAm5CVmulQWN6Ddod2ZoA3euZ1zPvJPwIQ2GrOYaCJr3cFrrMIX+nQyBJHBHYxUAPcM+Q==
   dependencies:
     base64-js "^1.3.0"
     fast-deep-equal "^2.0.1"
     uuid "^8.0.0"
 
-launchdarkly-react-client-sdk@^3.0.0-alpha.1:
-  version "3.0.0-alpha.1"
-  resolved "https://registry.yarnpkg.com/launchdarkly-react-client-sdk/-/launchdarkly-react-client-sdk-3.0.0-alpha.1.tgz#666e675439426ea5fc13ff8fdc887ee1f6c5c3d7"
-  integrity sha512-A5BZcPHu5o0mLXWe/xlF7Ofl3ba8+Ocell1oTkWQOKAYXNuA4CsF9opxjLbG671fZDtjAuX3Yfud/SXKA5C71g==
+launchdarkly-react-client-sdk@^3.0.10:
+  version "3.0.10"
+  resolved "https://registry.yarnpkg.com/launchdarkly-react-client-sdk/-/launchdarkly-react-client-sdk-3.0.10.tgz#33816d939d9bd18b0723c0fd30b4772f2429f3de"
+  integrity sha512-ssb3KWe9z42+q8X2u32OrlDntGLsv0NP/p4E2Hx4O9RU0OeFm9v6omOlIk9SMsYEQD4QzLSXAp5L3cSN2ssLlA==
   dependencies:
     hoist-non-react-statics "^3.3.2"
-    launchdarkly-js-client-sdk "^3.0.0-alpha.3"
+    launchdarkly-js-client-sdk "^3.1.4"
     lodash.camelcase "^4.3.0"
 
 levn@^0.3.0, levn@~0.3.0:
@@ -5668,15 +5668,13 @@ raw-body@2.4.3:
     iconv-lite "0.4.24"
     unpipe "1.0.0"
 
-react-dom@^16.11.0:
-  version "16.14.0"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.14.0.tgz#7ad838ec29a777fb3c75c3a190f661cf92ab8b89"
-  integrity sha512-1gCeQXDLoIqMgqD3IO2Ah9bnf0w9kzhwN5q4FGnHZ67hBm9yePzB5JJAIQCc8x3pFnNlwFq4RidZggNAAkzWWw==
+react-dom@18.2.0:
+  version "18.2.0"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-18.2.0.tgz#22aaf38708db2674ed9ada224ca4aa708d821e3d"
+  integrity sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==
   dependencies:
     loose-envify "^1.1.0"
-    object-assign "^4.1.1"
-    prop-types "^15.6.2"
-    scheduler "^0.19.1"
+    scheduler "^0.23.0"
 
 react-is@^16.6.0, react-is@^16.7.0, react-is@^16.8.1:
   version "16.13.1"
@@ -5712,14 +5710,12 @@ react-router@5.2.0:
     tiny-invariant "^1.0.2"
     tiny-warning "^1.0.0"
 
-react@^16.11.0:
-  version "16.14.0"
-  resolved "https://registry.yarnpkg.com/react/-/react-16.14.0.tgz#94d776ddd0aaa37da3eda8fc5b6b18a4c9a3114d"
-  integrity sha512-0X2CImDkJGApiAlcf0ODKIneSwBPhqJawOa5wCtKbu7ZECrmS26NvtSILynQ66cgkT/RJ4LidJOc3bUESwmU8g==
+react@18.2.0:
+  version "18.2.0"
+  resolved "https://registry.yarnpkg.com/react/-/react-18.2.0.tgz#555bd98592883255fa00de14f1151a917b5d77d5"
+  integrity sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==
   dependencies:
     loose-envify "^1.1.0"
-    object-assign "^4.1.1"
-    prop-types "^15.6.2"
 
 read-pkg-up@^3.0.0:
   version "3.0.0"
@@ -6079,13 +6075,12 @@ safe-regex@^1.1.0:
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
   integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
 
-scheduler@^0.19.1:
-  version "0.19.1"
-  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.19.1.tgz#4f3e2ed2c1a7d65681f4c854fa8c5a1ccb40f196"
-  integrity sha512-n/zwRWRYSUj0/3g/otKDRPMh6qv2SYMWNq85IEa8iZyAv8od9zDYpGSnpBEjNgcMNq6Scbu5KfIPxNF72R/2EA==
+scheduler@^0.23.0:
+  version "0.23.0"
+  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.23.0.tgz#ba8041afc3d30eb206a487b6b384002e4e61fdfe"
+  integrity sha512-CtuThmgHNg7zIZWAXi3AsyIzA3n4xx7aNyjwC2VJldO2LMVDhFK+63xGqq6CsJH4rTAt6/M+N4GhZiDYPx9eUw==
   dependencies:
     loose-envify "^1.1.0"
-    object-assign "^4.1.1"
 
 schema-utils@^1.0.0:
   version "1.0.0"

--- a/examples/hoc/package.json
+++ b/examples/hoc/package.json
@@ -4,7 +4,7 @@
   "description": "Example usage of launchdarkly-react-client-sdk",
   "main": "src/server/index.js",
   "scripts": {
-    "start": "node src/server/index.js",
+    "start": "NODE_OPTIONS=--openssl-legacy-provider node src/server/index.js",
     "lint": "eslint ./src",
     "serve": "webpack-serve webpack.config.server",
     "postinstall": "cd ../../ && yarn link-dev"
@@ -27,11 +27,11 @@
   "dependencies": {
     "@babel/polyfill": "^7.2.5",
     "express": "^4.17.3",
-    "launchdarkly-react-client-sdk": "^3.0.0-alpha.1",
+    "launchdarkly-react-client-sdk": "^3.0.10",
     "lodash": "^4.17.21",
     "prop-types": "^15.7.2",
-    "react": "^16.11.0",
-    "react-dom": "^16.11.0",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
     "react-router-dom": "^5.1.2",
     "styled-components": "^4.1.3"
   },

--- a/examples/hoc/src/client/index.js
+++ b/examples/hoc/src/client/index.js
@@ -1,11 +1,10 @@
 import React from 'react';
-import { render } from 'react-dom';
+import { createRoot } from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom';
 import App from '../universal/app';
 
-render(
+createRoot(document.getElementById('reactDiv')).render(
   <BrowserRouter>
     <App />
-  </BrowserRouter>,
-  document.getElementById('reactDiv'),
+  </BrowserRouter>
 );

--- a/examples/hoc/yarn.lock
+++ b/examples/hoc/yarn.lock
@@ -4577,30 +4577,30 @@ latest-version@^3.0.0:
   dependencies:
     package-json "^4.0.0"
 
-launchdarkly-js-client-sdk@^3.0.0-alpha.3:
-  version "3.0.0-alpha.4"
-  resolved "https://registry.yarnpkg.com/launchdarkly-js-client-sdk/-/launchdarkly-js-client-sdk-3.0.0-alpha.4.tgz#fcea9bc37e05bb2a3373a4cddf1df7c6101edbd4"
-  integrity sha512-tJXCEx/8bwBTL+PbWHiP2QOgQ3kj4w5XS2nD1GlD6Mbm13o7lXabAQLCMpIfSytFErbBU7OuoS9+rOSPegwYeg==
+launchdarkly-js-client-sdk@^3.1.4:
+  version "3.1.4"
+  resolved "https://registry.yarnpkg.com/launchdarkly-js-client-sdk/-/launchdarkly-js-client-sdk-3.1.4.tgz#e613cb53412533c07ccf140ae570fc994c59758d"
+  integrity sha512-yq0FeklpVuHMSRz7jfUAfyM7I/659RvGztqJ0Y9G5eN/ZrG1o2W61ZU0Nrv/gqZCtLXjarh/u1otxSFFBjTpHw==
   dependencies:
     escape-string-regexp "^4.0.0"
-    launchdarkly-js-sdk-common "5.0.0-alpha.5"
+    launchdarkly-js-sdk-common "5.0.3"
 
-launchdarkly-js-sdk-common@5.0.0-alpha.5:
-  version "5.0.0-alpha.5"
-  resolved "https://registry.yarnpkg.com/launchdarkly-js-sdk-common/-/launchdarkly-js-sdk-common-5.0.0-alpha.5.tgz#52fe835ad4c51e2579a3bcd6af2012a2e424280a"
-  integrity sha512-YvPAMm/El6y9pCv3yEVZy0ck5R1FRyoqjMUYRxOo73z/wqmMXuRVOY5KQMmnM6Sqvhv0lanSJK77oIpMyj0IZw==
+launchdarkly-js-sdk-common@5.0.3:
+  version "5.0.3"
+  resolved "https://registry.yarnpkg.com/launchdarkly-js-sdk-common/-/launchdarkly-js-sdk-common-5.0.3.tgz#345f899f5779be8b03d6599978c855eb838d8b7f"
+  integrity sha512-wKG8UsVbPVq8+7eavgAm5CVmulQWN6Ddod2ZoA3euZ1zPvJPwIQ2GrOYaCJr3cFrrMIX+nQyBJHBHYxUAPcM+Q==
   dependencies:
     base64-js "^1.3.0"
     fast-deep-equal "^2.0.1"
     uuid "^8.0.0"
 
-launchdarkly-react-client-sdk@^3.0.0-alpha.1:
-  version "3.0.0-alpha.1"
-  resolved "https://registry.yarnpkg.com/launchdarkly-react-client-sdk/-/launchdarkly-react-client-sdk-3.0.0-alpha.1.tgz#666e675439426ea5fc13ff8fdc887ee1f6c5c3d7"
-  integrity sha512-A5BZcPHu5o0mLXWe/xlF7Ofl3ba8+Ocell1oTkWQOKAYXNuA4CsF9opxjLbG671fZDtjAuX3Yfud/SXKA5C71g==
+launchdarkly-react-client-sdk@^3.0.10:
+  version "3.0.10"
+  resolved "https://registry.yarnpkg.com/launchdarkly-react-client-sdk/-/launchdarkly-react-client-sdk-3.0.10.tgz#33816d939d9bd18b0723c0fd30b4772f2429f3de"
+  integrity sha512-ssb3KWe9z42+q8X2u32OrlDntGLsv0NP/p4E2Hx4O9RU0OeFm9v6omOlIk9SMsYEQD4QzLSXAp5L3cSN2ssLlA==
   dependencies:
     hoist-non-react-statics "^3.3.2"
-    launchdarkly-js-client-sdk "^3.0.0-alpha.3"
+    launchdarkly-js-client-sdk "^3.1.4"
     lodash.camelcase "^4.3.0"
 
 levn@^0.3.0, levn@~0.3.0:
@@ -5842,15 +5842,13 @@ rc@^1.0.1, rc@^1.1.6:
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
 
-react-dom@^16.11.0:
-  version "16.14.0"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.14.0.tgz#7ad838ec29a777fb3c75c3a190f661cf92ab8b89"
-  integrity sha512-1gCeQXDLoIqMgqD3IO2Ah9bnf0w9kzhwN5q4FGnHZ67hBm9yePzB5JJAIQCc8x3pFnNlwFq4RidZggNAAkzWWw==
+react-dom@18.2.0:
+  version "18.2.0"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-18.2.0.tgz#22aaf38708db2674ed9ada224ca4aa708d821e3d"
+  integrity sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==
   dependencies:
     loose-envify "^1.1.0"
-    object-assign "^4.1.1"
-    prop-types "^15.6.2"
-    scheduler "^0.19.1"
+    scheduler "^0.23.0"
 
 react-is@^16.6.0, react-is@^16.7.0, react-is@^16.8.1:
   version "16.13.1"
@@ -5886,14 +5884,12 @@ react-router@5.2.0:
     tiny-invariant "^1.0.2"
     tiny-warning "^1.0.0"
 
-react@^16.11.0:
-  version "16.14.0"
-  resolved "https://registry.yarnpkg.com/react/-/react-16.14.0.tgz#94d776ddd0aaa37da3eda8fc5b6b18a4c9a3114d"
-  integrity sha512-0X2CImDkJGApiAlcf0ODKIneSwBPhqJawOa5wCtKbu7ZECrmS26NvtSILynQ66cgkT/RJ4LidJOc3bUESwmU8g==
+react@18.2.0:
+  version "18.2.0"
+  resolved "https://registry.yarnpkg.com/react/-/react-18.2.0.tgz#555bd98592883255fa00de14f1151a917b5d77d5"
+  integrity sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==
   dependencies:
     loose-envify "^1.1.0"
-    object-assign "^4.1.1"
-    prop-types "^15.6.2"
 
 read-pkg-up@^3.0.0:
   version "3.0.0"
@@ -6231,13 +6227,12 @@ safe-regex@^1.1.0:
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
   integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
 
-scheduler@^0.19.1:
-  version "0.19.1"
-  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.19.1.tgz#4f3e2ed2c1a7d65681f4c854fa8c5a1ccb40f196"
-  integrity sha512-n/zwRWRYSUj0/3g/otKDRPMh6qv2SYMWNq85IEa8iZyAv8od9zDYpGSnpBEjNgcMNq6Scbu5KfIPxNF72R/2EA==
+scheduler@^0.23.0:
+  version "0.23.0"
+  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.23.0.tgz#ba8041afc3d30eb206a487b6b384002e4e61fdfe"
+  integrity sha512-CtuThmgHNg7zIZWAXi3AsyIzA3n4xx7aNyjwC2VJldO2LMVDhFK+63xGqq6CsJH4rTAt6/M+N4GhZiDYPx9eUw==
   dependencies:
     loose-envify "^1.1.0"
-    object-assign "^4.1.1"
 
 schema-utils@^1.0.0:
   version "1.0.0"

--- a/link-dev.sh
+++ b/link-dev.sh
@@ -1,14 +1,14 @@
 #!/bin/bash
 
 echo "===== Installing all dependencies..."
-npm install
+npm install --force
 
 echo "===== Building react sdk"
 npm run build
 
 echo "===== Install prod dependencies"
 rm -rf node_modules
-npm install --production
+npm install --force --omit=dev
 
 echo "===== Linking to examples"
 declare -a examples=(async-provider hoc typescript deferred-initialization)

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
   },
   "dependencies": {
     "hoist-non-react-statics": "^3.3.2",
-    "launchdarkly-js-client-sdk": "^3.1.4",
+    "launchdarkly-js-client-sdk": "^3.2.0",
     "lodash.camelcase": "^4.3.0"
   },
   "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "launchdarkly-react-client-sdk",
-  "version": "3.0.9",
+  "version": "3.0.10",
   "description": "LaunchDarkly SDK for React",
   "author": "LaunchDarkly <team@launchdarkly.com>",
   "license": "Apache-2.0",

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "@types/hoist-non-react-statics": "^3.3.1",
     "@types/jest": "^27.0.3",
     "@types/lodash.camelcase": "^4.3.6",
+    "@types/node": "^14.14.31",
     "@types/prop-types": "^15.7.4",
     "@types/react": "^18.0.3",
     "@types/react-dom": "^18.0.0",


### PR DESCRIPTION
## [3.1.0] - 2024-03-19
### Changed:
- Redact anonymous attributes within feature events
- Always inline contexts for feature events

### Fixed:
- Pin dev version of node to compatible types.