### PR TITLE
prepare 3.3.1 release

### DIFF
--- a/src/asyncWithLDProvider.test.tsx
+++ b/src/asyncWithLDProvider.test.tsx
@@ -39,7 +39,14 @@ const renderWithConfig = async (config: AsyncProviderConfig) => {
   const { getByText } = render(
     <LDProvider>
       <Consumer>
-        {(value) => <span>Received: {`Flags: ${JSON.stringify(value.flags)}.\nError: ${value.error?.message}.`}</span>}
+        {(value) => (
+          <span>
+            Received:{' '}
+            {`Flags: ${JSON.stringify(value.flags)}.
+            Error: ${value.error?.message}.
+            ldClient: ${value.ldClient ? 'initialized' : 'undefined'}.`}
+          </span>
+        )}
       </Consumer>
     </LDProvider>,
   );
@@ -316,6 +323,11 @@ describe('asyncWithLDProvider', () => {
     };
     const receivedNode = await renderWithConfig({ clientSideID, context, options });
     expect(receivedNode).toHaveTextContent('{"testFlag":true,"anotherTestFlag":true}');
+  });
+
+  test('internal ldClient state should be initialised', async () => {
+    const receivedNode = await renderWithConfig({ clientSideID, context, options });
+    expect(receivedNode).toHaveTextContent('ldClient: initialized');
   });
 
   test('ldClient is initialised correctly with target flags', async () => {

--- a/src/asyncWithLDProvider.tsx
+++ b/src/asyncWithLDProvider.tsx
@@ -52,6 +52,7 @@ export default async function asyncWithLDProvider(config: AsyncProviderConfig) {
     const [ldData, setLDData] = useState<ProviderState>(() => ({
       unproxiedFlags: initialFlags,
       ...getFlagsProxy(ldClient, initialFlags, reactOptions, targetFlags),
+      ldClient,
       error,
     }));
 


### PR DESCRIPTION
## [3.3.1] - 2024-05-28
### Fixed:
- Fixed a bug introduced after the init timeout change. The ldClient object was omitted from provider state, causing the useLDClient hook to return undefined.