### PR TITLE
prepare 3.3.2 release

### DIFF
--- a/rollup.config.ts
+++ b/rollup.config.ts
@@ -5,7 +5,7 @@ import json from '@rollup/plugin-json';
 import resolve from '@rollup/plugin-node-resolve';
 import terser from '@rollup/plugin-terser';
 
-const plugins = [resolve(), esbuild(), json(), terser(), filesize()];
+const plugins = [resolve(), esbuild({ target: 'es6' }), json(), terser(), filesize()];
 const external = /node_modules/;
 
 export default [


### PR DESCRIPTION
## [3.3.2] - 2024-05-28
### Fixed:
- Set esbuild to target ES2015 aka ES6 so the build is backwards compatible. This is needed because `rollup-plugin-esbuild` [v6](https://github.com/egoist/rollup-plugin-esbuild/releases/tag/v6.0.0) now defaults to es2020 by default and no longer respects tsconfig.json's target. Fixes #283.