### PR TITLE
feat(typescript): export the LDProps interface for access in application code

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -155,4 +155,6 @@ export interface AllFlagsLDClient {
  */
 export type LDFlagKeyMap = Record<string, string>;
 
+export { LDProps } from './withLDConsumer';
+
 export * from 'launchdarkly-js-client-sdk';

--- a/src/types.ts
+++ b/src/types.ts
@@ -155,6 +155,6 @@ export interface AllFlagsLDClient {
  */
 export type LDFlagKeyMap = Record<string, string>;
 
-export { LDProps } from './withLDConsumer';
+export { type LDProps } from './withLDConsumer';
 
 export * from 'launchdarkly-js-client-sdk';


### PR DESCRIPTION
**Requirements**

- [ ] I have added test coverage for new or changed functionality
- [x] I have followed the repository's [pull request submission guidelines](../blob/main/CONTRIBUTING.md#submitting-pull-requests)
- [ ] I have validated my changes against all supported platform versions

**Related issues**

https://github.com/launchdarkly/react-client-sdk/issues/322

**Describe the solution you've provided**

With this change, it is possible to import the LDProps type from the library like this:
```ts
import type {LDProps} from 'launchdarkly-react-client-sdk'
```

**Describe alternatives you've considered**

The current workarounds have involved duplicating the TS interface into the codebase or attempting to infer it from the `withLDConsumer` parameter types. The latter option does not work well with IDEs and IntelliSense.

**Additional context**

N/A
