### PR TITLE
chore: remove deprecated tslint dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 **/junit.xml
 npm-debug.log
 yarn-error.log
+pnpm-debug.log
 node_modules
 dist
 lib
@@ -12,5 +13,6 @@ test-types.js
 docs/build/
 yarn.lock
 package-lock.json
+pnpm-lock.yaml
 .npmrc
 docs/

--- a/examples/deferred-initialization/src/App.tsx
+++ b/examples/deferred-initialization/src/App.tsx
@@ -3,7 +3,6 @@ import logo from './logo.svg';
 import Welcome from './welcome';
 import { LDProvider, LDContext } from 'launchdarkly-react-client-sdk';
 
-// tslint:disable-next-line:no-import-side-effect
 import './App.css';
 
 const clientSideID = process.env.REACT_APP_LD_CLIENT_SIDE_ID ?? '';

--- a/examples/deferred-initialization/src/index.tsx
+++ b/examples/deferred-initialization/src/index.tsx
@@ -1,10 +1,8 @@
 import React from 'react';
-// tslint:disable-next-line:no-submodule-imports
 import ReactDOM from 'react-dom/client';
 import App from './App';
 import reportWebVitals from './reportWebVitals';
 
-// tslint:disable-next-line:no-import-side-effect
 import './index.css';
 
 const root = ReactDOM.createRoot(document.getElementById('root') as HTMLElement);

--- a/examples/deferred-initialization/src/welcome.tsx
+++ b/examples/deferred-initialization/src/welcome.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { useFlags } from 'launchdarkly-react-client-sdk';
 
-// tslint:disable-next-line:no-import-side-effect
 import './App.css';
 
 function Welcome() {

--- a/package.json
+++ b/package.json
@@ -78,7 +78,6 @@
     "rollup-plugin-dts": "^6.1.0",
     "rollup-plugin-esbuild": "^6.1.1",
     "ts-jest": "^29.2.2",
-    "tslint": "^6.1.3",
     "typedoc": "^0.26.5",
     "typescript": "^5.5.4",
     "typescript-eslint": "^8.0.0"

--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
     "rollup-plugin-dts": "^6.1.0",
     "rollup-plugin-esbuild": "^6.1.1",
     "ts-jest": "^29.2.2",
+    "tslib": "^2.8.1",
     "typedoc": "^0.26.5",
     "typescript": "^5.5.4",
     "typescript-eslint": "^8.0.0"


### PR DESCRIPTION
**Requirements**

- [ ] I have added test coverage for new or changed functionality
- [x] I have followed the repository's [pull request submission guidelines](../blob/main/CONTRIBUTING.md#submitting-pull-requests)
- [ ] I have validated my changes against all supported platform versions

**Changes**

- remove `tslint` dependency from root `package.json`
- remove `tslint-disable-next-line` statements from various files
- add `pnpm-lock.yaml` and `pnpm-debug.log` files to `.gitignore`

**Related issues**

When running dependency installation with e.g. `pnpm` in this repository, I encountered the following warning:

```
 WARN  deprecated tslint@6.1.3: TSLint has been deprecated in favor of ESLint. Please see https://github.com/palantir/tslint/issues/4534 for more information.
```


The migration from `tslint` to `eslint` was done in https://github.com/launchdarkly/react-client-sdk/pull/297, but it seems that the `tslint` dependency has not been removed as part of it.
