### PR TITLE
ci: replace reusable workflow with gh-actions composite actions

### DIFF
--- a/.github/workflows/dependency-scan.yml
+++ b/.github/workflows/dependency-scan.yml
@@ -7,8 +7,24 @@ on:
       - main
 
 jobs:
-  dependency-scan:
-    uses: launchdarkly/gh-actions/.github/workflows/dependency-scan.yml@main
-    with:
-      types: 'nodejs'
-    secrets: inherit
+  generate-nodejs-sbom:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
+
+      - name: Generate SBOM
+        uses: launchdarkly/gh-actions/actions/dependency-scan/generate-sbom@main
+        with:
+          types: 'nodejs'
+
+  evaluate-policy:
+    runs-on: ubuntu-latest
+    needs:
+      - generate-nodejs-sbom
+    steps:
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
+
+      - name: Evaluate SBOM Policy
+        uses: launchdarkly/gh-actions/actions/dependency-scan/evaluate-policy@main
+        with:
+          artifacts-pattern: bom-*


### PR DESCRIPTION
**Requirements**

- [x] I have added test coverage for new or changed functionality
- [x] I have followed the repository's [pull request submission guidelines](../blob/main/CONTRIBUTING.md#submitting-pull-requests)
- [x] I have validated my changes against all supported platform versions

N/A — CI-only change, no application code modified.

**Related issues**

A similar change was made in `launchdarkly/hello-node-typescript` to replace `common-workflows` reusable workflow usage.

**Describe the solution you've provided**

Replaces the reusable workflow reference (`launchdarkly/gh-actions/.github/workflows/dependency-scan.yml@main`) with direct usage of the two composite actions from `launchdarkly/gh-actions/actions/dependency-scan/`:

- `generate-sbom` — generates the SBOM for `nodejs`
- `evaluate-policy` — evaluates the SBOM against the license policy

This aligns with how other SDK repos (`js-client-sdk`, `js-core`, `openfeature-node-server`, etc.) already configure their dependency scan workflows.

**Describe alternatives you've considered**

None — this is a direct migration to the recommended action pattern.

**Additional context**

The previous reusable workflow path (`gh-actions/.github/workflows/dependency-scan.yml`) does not exist in the `gh-actions` repo, so the old workflow was non-functional.

**Human review checklist**
- [ ] Verify the two-job structure (`generate-nodejs-sbom` → `evaluate-policy`) matches the standard org pattern
- [ ] Confirm the dependency scan workflow runs successfully on this PR

Link to Devin session: https://app.devin.ai/sessions/2783d2578c67461aa0af3b814ea886b2
Requested by: @kinyoklion

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only workflow change; main risk is breaking dependency scanning if the new jobs/artifact pattern are misconfigured.
> 
> **Overview**
> Updates the `Dependency Scan` GitHub Actions workflow to stop calling the `launchdarkly/gh-actions` reusable workflow and instead run two explicit jobs.
> 
> The new flow generates a Node.js SBOM via `actions/dependency-scan/generate-sbom@main`, then gates on a follow-up `evaluate-policy` job that runs `actions/dependency-scan/evaluate-policy@main` against the produced `bom-*` artifacts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e3b9b7c2f878b86364784132e3525dd888dc89e1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->