### PR TITLE
chore: replace rollup-plugin-dts with tsc for declaration emission

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,12 +13,12 @@
     "bindings"
   ],
   "exports": {
-    "types": "./lib/index.d.ts",
+    "types": "./lib/types/index.d.ts",
     "require": "./lib/cjs/index.js",
     "import": "./lib/esm/index.js"
   },
   "main": "./lib/cjs/index.js",
-  "types": "./lib/index.d.ts",
+  "types": "./lib/types/index.d.ts",
   "files": [
     "lib",
     "src",
@@ -29,7 +29,7 @@
     "test": "jest",
     "test:junit": "jest --ci --reporters=default",
     "clean": "rimraf lib/*",
-    "rb": "rollup -c --configPlugin typescript",
+    "rb": "rollup -c --configPlugin typescript && tsc -p tsconfig.build.json",
     "rbw": "npm run rb --watch",
     "build": "npm run clean && npm run rb",
     "lint": "eslint ./src",
@@ -75,7 +75,6 @@
     "react-test-renderer": "^18.0.0",
     "rimraf": "^6.0.1",
     "rollup": "^4.19.0",
-    "rollup-plugin-dts": "^6.1.0",
     "rollup-plugin-esbuild": "^6.1.1",
     "ts-jest": "^29.2.2",
     "tslib": "^2.8.1",

--- a/rollup.config.ts
+++ b/rollup.config.ts
@@ -1,4 +1,3 @@
-import dts from 'rollup-plugin-dts';
 import esbuild from 'rollup-plugin-esbuild';
 import json from '@rollup/plugin-json';
 import resolve from '@rollup/plugin-node-resolve';
@@ -32,13 +31,5 @@ export default [
     ],
     plugins,
     external,
-  },
-  {
-    input: 'src/index.ts',
-    plugins: [dts(), json()],
-    output: {
-      file: 'lib/index.d.ts',
-      format: 'es',
-    },
   },
 ];

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,0 +1,14 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "declaration": true,
+    "declarationDir": "lib/types",
+    "emitDeclarationOnly": true,
+    "sourceMap": false,
+    "sourceRoot": null,
+    "noEmit": false
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "lib", "dist", "example", "**/*.test.ts", "**/*.test.tsx"]
+}


### PR DESCRIPTION
Remove rollup-plugin-dts and emit type declarations directly with tsc via a new tsconfig.build.json. The build now produces lib/types/*.d.ts alongside the existing lib/cjs and lib/esm bundles; the `types` / `exports.types` entries in package.json point at lib/types/index.d.ts.

The rollup-plugin-dts was just combining all the types into a single .d.ts file for this project. It wasn't rolling up the .d.ts from its dependencies. 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Primarily build/publish metadata changes, but it affects the emitted/packaged TypeScript declaration layout and could break consumers if the new `lib/types` output differs or is incomplete.
> 
> **Overview**
> Build output now generates `.d.ts` files via `tsc -p tsconfig.build.json` into `lib/types/` (declarations-only), rather than using Rollup to bundle a single `lib/index.d.ts`.
> 
> `package.json` and `exports.types` are updated to point consumers at `./lib/types/index.d.ts`, and `rollup-plugin-dts` is removed from the Rollup config and dev dependencies.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9227a7d6bf884cc92c730194d05085709dcef1f2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->