### PR TITLE
fix: adding reference to new SDK location

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,10 @@
+# Use [@launchdarkly/react-sdk](https://www.npmjs.com/package/@launchdarkly/react-sdk) instead of this package.
+
+The `launchdarkly-react-client-sdk` project has been renamed `@launchdarkly/react-sdk` and all future releases will be made from the
+[new repository](https://github.com/launchdarkly/js-core/tree/main/packages/sdk/react). Please consider upgrading and filing issues
+and requests in that repository's [issue tracker](https://github.com/launchdarkly/js-core/issues?q=is%3Aissue+is%3Aopen+label%3A%22package%3A+sdk%2Freact%22+sort%3Aupdated-desc).
+# ☝️☝️☝️☝️☝️☝️
+
 # LaunchDarkly Client-side SDK for React
 
 [![Circle CI](https://circleci.com/gh/launchdarkly/react-client-sdk/tree/main.svg?style=svg)](https://circleci.com/gh/launchdarkly/react-client-sdk/tree/main)


### PR DESCRIPTION

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/launchdarkly/react-client-sdk/pull/389" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that adds guidance for migrating to the renamed package and new repository/issue tracker.
> 
> **Overview**
> Adds a prominent notice at the top of `README.md` stating that `launchdarkly-react-client-sdk` has been renamed to `@launchdarkly/react-sdk`, and links to the new repository location and issue tracker for future updates/support.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b4fb9610b332593abf37a3891771ca85e4e4d456. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->