### PR TITLE
fix: bump js-client-sdk

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "jest": "^29.7.0",
     "jest-environment-jsdom": "^29.7.0",
     "jest-environment-jsdom-global": "^4.0.0",
+    "parse5": "7.2.1",
     "prettier": "^3.3.3",
     "prop-types": "^15.7.2",
     "react": "^18.0.0",
@@ -80,12 +81,11 @@
     "tslib": "^2.8.1",
     "typedoc": "^0.28.17",
     "typescript": "^5.5.4",
-    "typescript-eslint": "^8.0.0",
-    "parse5": "7.2.1"
+    "typescript-eslint": "^8.0.0"
   },
   "dependencies": {
     "hoist-non-react-statics": "^3.3.2",
-    "launchdarkly-js-client-sdk": "^3.9.0",
+    "launchdarkly-js-client-sdk": "^3.9.3",
     "lodash.camelcase": "^4.3.0"
   },
   "peerDependencies": {


### PR DESCRIPTION
This commit will fix GoalManager bypassing eventUrlTransformer

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency patch bump with no React SDK source changes; risk is limited to upstream SDK event/URL behavior.
> 
> **Overview**
> Bumps the **`launchdarkly-js-client-sdk`** dependency from **^3.9.0** to **^3.9.3** so React apps pick up a fix where **GoalManager** was not honoring **`eventUrlTransformer`**. The only other diff is a cosmetic reorder of **`parse5`** in **devDependencies**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b7e36dc34f77867f6ee93cfb2492bf7b3656704a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->