### PR TITLE
chore: consolidate safe dependency updates and tighten Dependabot policy

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,11 +4,25 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    # Dependency quarantine: only adopt releases that are at least 7 days old.
     cooldown:
       default-days: 7
+    # Restrict version updates to the current major version. Security updates are
+    # exempt (update-types does not affect security updates), so Dependabot may
+    # still bump a major version when required to resolve a vulnerability.
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
       interval: "daily"
+    # Dependency quarantine: only adopt releases that are at least 7 days old.
     cooldown:
       default-days: 7
+    # Restrict version updates to the current major version. Security updates are
+    # exempt (update-types does not affect security updates), so Dependabot may
+    # still bump a major version when required to resolve a vulnerability.
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "@types/react": "^18.0.3",
     "@types/react-dom": "^18.0.0",
     "@types/react-test-renderer": "^18.0.0",
-    "esbuild": "^0.24.0",
+    "esbuild": "^0.28.1",
     "eslint": "^9.8.0",
     "jest": "^29.7.0",
     "jest-environment-jsdom": "^29.7.0",


### PR DESCRIPTION
**Requirements**

- [x] I have added test coverage for new or changed functionality (existing suite validates the build/runtime; this change is dev-tooling + config only)
- [x] I have followed the repository's [pull request submission guidelines](../blob/main/CONTRIBUTING.md#submitting-pull-requests)
- [x] I have validated my changes against all supported platform versions

**Related issues**

Replaces the currently open Dependabot PRs (#374, #377, #388, #392, #393, #394), all of which are major-version bumps.

**Describe the solution you've provided**

This consolidates dependency maintenance into a single, tested PR and codifies a safer Dependabot policy.

1. **Dependency update (`package.json`)** — bumps the `esbuild` devDependency `^0.24.0` → `^0.28.1` to resolve the moderate advisory GHSA-67mh-4wv8-2f99 (esbuild `<=0.24.2` dev server request). `npm audit` now reports **0 vulnerabilities**. esbuild `0.28.1` was released 2026-06-11 (~25 days ago), satisfying a 7-day quarantine. This is the only actionable update under the new same-major policy: `npm outdated` shows every other outstanding update is a major bump with no security justification, and everything else is already at the latest version within its current major.

2. **Dependabot policy (`.github/dependabot.yml`)** — for both the `npm` and `github-actions` ecosystems:
   - `cooldown: { default-days: 7 }` enforces the dependency quarantine (only adopt releases ≥7 days old) going forward.
   - `ignore` on `dependency-name: "*"` with `update-types: ["version-update:semver-major"]` restricts version-update PRs to the current major. Per GitHub's docs, `update-types` does not affect security updates, so Dependabot will still open a major-version PR when required to resolve a vulnerability.

Validated locally: `npm run build`, `npm run lint`, `tsc`, and the full `jest` suite (93 tests) all pass, and `npm audit` is clean.

**Describe alternatives you've considered**

- Adopting the open React 19 devDependency bumps (react, react-dom, react-test-renderer and their `@types`) and `actions/setup-node` v6. These are all major bumps with no security driver, so they are intentionally excluded under the new same-major policy. They can be pursued separately as deliberate, tested major upgrades if desired.
- A global `semver-major` ignore alone (without noting the security exemption): documented behavior confirms security updates are unaffected by `update-types`, so the security-major path remains open.

**Additional context**

The 7-day quarantine and same-major restriction reduce exposure to supply-chain risk from freshly published or major releases while keeping security fixes flowing.


Link to Devin session: https://app.devin.ai/sessions/9a6e6afb929646c3b9d14c4f13a17601
Requested by: @kinyoklion

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> DevDependency and Dependabot config only; no changes to the published SDK runtime or consumer-facing APIs.
> 
> **Overview**
> Bumps the **esbuild** devDependency from `^0.24.0` to `^0.28.1` to address moderate advisory GHSA-67mh-4wv8-2f99 (dev-server request handling in older esbuild). This is a build-time-only change.
> 
> Updates **`.github/dependabot.yml`** for both **npm** and **github-actions**: documents the existing 7-day **cooldown** quarantine and adds a global **`ignore`** for **`version-update:semver-major`**, so routine Dependabot PRs stay on the current major. Security-driven updates can still propose major bumps per GitHub’s rules.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 503cc1f60ea121d454c114f431ef1e4aa049d70d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->