### PR TITLE
fix: update launchdarkly-js-client-sdk to ^3.9.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
   },
   "dependencies": {
     "hoist-non-react-statics": "^3.3.2",
-    "launchdarkly-js-client-sdk": "^3.9.3",
+    "launchdarkly-js-client-sdk": "^3.9.4",
     "lodash.camelcase": "^4.3.0"
   },
   "peerDependencies": {


### PR DESCRIPTION
**Requirements**

- [x] I have added test coverage for new or changed functionality — n/a, dependency bump only
- [x] I have followed the repository's pull request submission guidelines
- [x] I have validated my changes against all supported platform versions

**Related issues**

Propagates the `launchdarkly-js-sdk-common` v5.8.2 bugfix into the React SDK via `launchdarkly-js-client-sdk` 3.9.4 (released to pick up common 5.8.2 — https://github.com/launchdarkly/js-client-sdk/pull/349).

**Describe the solution you've provided**

Raise the `launchdarkly-js-client-sdk` floor from `^3.9.3` to `^3.9.4`.

```diff
-    "launchdarkly-js-client-sdk": "^3.9.3",
+    "launchdarkly-js-client-sdk": "^3.9.4",
```

The existing caret range already resolves 3.9.4 on a fresh install; this raises the minimum so the fix (common 5.8.2, pulled in transitively by js-client-sdk 3.9.4) is guaranteed. Verified locally against 3.9.4: `npm test` (93 passed), `npm run lint`, and `npm run check-typescript` all pass.

**Describe alternatives you've considered**

Leaving the range at `^3.9.3` — it already permits 3.9.4, but does not guarantee the minimum, so the floor bump is preferred.

**Additional context**

Part of rolling out `launchdarkly-js-sdk-common` v5.8.2 across the client-side JS SDKs. Companion PRs: js-client-sdk#349 (merged), node-client-sdk#72 (merged), vue-client-sdk#85.

Link to Devin session: https://app.devin.ai/sessions/3ed6e570c11b4abb80724e0f2bc5f03e
Requested by: @joker23

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single dependency floor bump with no application code changes; behavior change comes only from the upstream client/common SDK patch.
> 
> **Overview**
> Raises the **`launchdarkly-js-client-sdk`** dependency floor from **`^3.9.3`** to **`^3.9.4`** so installs always pick up **js-client-sdk 3.9.4**, which transitively includes **`launchdarkly-js-sdk-common` v5.8.2**.
> 
> This is a **dependency-only** change (no React SDK source updates); it aligns this package with the same common-SDK bugfix rollout as the other client SDK PRs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0feccc7948e6588e7a7853f08ac4d44203adbe50. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->